### PR TITLE
UICCAI-748: Import tool SSML tweaks

### DIFF
--- a/cx-phrases/README.md
+++ b/cx-phrases/README.md
@@ -1,3 +1,9 @@
+# SSML Processing
+We process a number of token types to surround with SSML tags in the Output Audio Text section of an agent fulfillment. These include by default
+<i>URLs, phone numbers, percentages,</i> and <i>numbers</i>. We've defined some custom rules as well - letter sequences that don't make sense
+in English, tokens that we specifically want to pronounce versus spell out, and some custom matching rules to replace very specific strings with desired
+SSML. These are all done using regexes or matching within a list, and therefore are overridable and customizable.
+
 # Configuration
 Regexes, URL separators, and an allowlist of short tokens can be found in the `defaults.conf` file. Tokens in a fulfillment phrase
 that match these items will be surrounded with appropriate ssml tags during import. Short tokens appearing in the allowlist will be read
@@ -14,14 +20,21 @@ verbatim. To overwrite these values, add custom values to the `config.conf` file
     URL_VERBATIM_TOKENS: []
     MATCH_URL_REGEX: ""
 
-    # Custom matchers can be defined using regexes and replacements starting with "CUSTOM_MATCH_":
+    # Custom match rules can be defined using regexes and replacements in the CUSTOM_MATCH_REPLACE_LIST", along with language code values
+    # to indicate the languages in which to perform the match/replace:
     CUSTOM_MATCH_REPLACE_LIST: [ 
        {
+            languages: "en",
             match: "^.*$",
-            replace: "hello 1"
+            replace: "hello"
         }, {
+            languages: "en,es",
             match: "^.*$",
-            replace: "hello 2"
+            replace: "hola"
+        }, {
+            languages: "all",
+            match: "^.*$",
+            replace: ":)"
         } 
     ]
 }

--- a/cx-phrases/defaults.conf
+++ b/cx-phrases/defaults.conf
@@ -3,12 +3,25 @@
     MATCH_URL_REGEX: "\\s\\w+\\.\\w+(?:[.\\/\\-]\\w+)*\\b"
     MATCH_PHONE_REGEX: "\\b(\\d{3}-\\d{3}-\\d{4})\\b"
     MATCH_PERCENTAGE_REGEX: "\\b\\d+(\\.\\d+)*\\s*%(?!\"|<)\\B"
-    MATCH_NUMBERS_REGEX: "\\b(?<!\\d{3}-\\d{3}-)\\b\\d+\\b(?!-\\d{3}-\\d{4})(?!-\\d{1,4})(?!%\">|:|-)\\b"
-    SHORT_TOKEN_WHITELIST: [ "com", "org" ]
+    MATCH_NUMBERS_REGEX: "\\b(?<!\\d{3}-\\d{3}-)\\b\\d+\\b(?!-\\d{3}-\\d{4})(?!-\\d{1,4})(?!%\">|:|-|\\s[Gg])\\b"
+    SHORT_TOKEN_WHITELIST: [ "com", "org1" ]
     INVALID_CONSONANT_SEQUENCE: "\\b.*([^aeiouy]{5,}|[^aeiou][^aeiouy]{4,}[^aeiou]|[hjmnqvwxz]r|[cdfghjqvwxz]s|[dhjmnqrtvxwz]l|sth|kpy|ww|hh|jj|kk|qq|vv|xx).*\\b"
-    URL_VERBATIM_TOKENS: [ "dcfaq" ]
+    URL_VERBATIM_TOKENS: [ "dcfaq", "ny.gov", "nys", "dol", "ny", "gov", "po", "nysdol" ]
     CUSTOM_MATCH_REPLACE_LIST: [{
-        match: "1099-G\\s+",
+        languages: "en",
+        match: "1099(-){0,1}\\s*[Gg]\\s*",
         replace: "1099-G <break time=\"300ms\"/> "
+    }, {
+        languages: "all",
+        match: "Albany",
+        replace: "A l b a n y "
+    }, {
+        languages: "en",
+        match: "A l b a n y",
+        replace: "Albany "
+    }, {
+        languages: "es",
+        match: "A l b a n y",
+        replace: "Albani "
     }]
 }

--- a/cx-phrases/defaults.conf
+++ b/cx-phrases/defaults.conf
@@ -4,7 +4,7 @@
     MATCH_PHONE_REGEX: "\\b(\\d{3}-\\d{3}-\\d{4})\\b"
     MATCH_PERCENTAGE_REGEX: "\\b\\d+(\\.\\d+)*\\s*%(?!\"|<)\\B"
     MATCH_NUMBERS_REGEX: "\\b(?<!\\d{3}-\\d{3}-)\\b\\d+\\b(?!-\\d{3}-\\d{4})(?!-\\d{1,4})(?!%\">|:|-|\\s[Gg])\\b"
-    SHORT_TOKEN_WHITELIST: [ "com", "org1" ]
+    SHORT_TOKEN_WHITELIST: [ "com", "org" ]
     INVALID_CONSONANT_SEQUENCE: "\\b.*([^aeiouy]{5,}|[^aeiou][^aeiouy]{4,}[^aeiou]|[hjmnqvwxz]r|[cdfghjqvwxz]s|[dhjmnqrtvxwz]l|sth|kpy|ww|hh|jj|kk|qq|vv|xx).*\\b"
     URL_VERBATIM_TOKENS: [ "dcfaq", "ny.gov", "nys", "dol", "ny", "gov", "po", "nysdol" ]
     CUSTOM_MATCH_REPLACE_LIST: [{

--- a/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/Ssml.kt
+++ b/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/Ssml.kt
@@ -1,6 +1,5 @@
 package io.nuvalence.cx.tools.phrases
 
-import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory

--- a/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/Ssml.kt
+++ b/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/Ssml.kt
@@ -1,5 +1,6 @@
 package io.nuvalence.cx.tools.phrases
 
+import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
@@ -110,8 +111,14 @@ fun addSsmlTags(phrase: String): String {
         .replace("\$session.params.web-site", "\$session.params.web-site-ssml")
         .replace("\$session.params.web-site-fwd", "\$session.params.web-site-fwd-ssml")
     var replacedCustom = replacedWebSite
-    CUSTOM_MATCH_REPLACE_LIST.forEach {
-        replacedCustom = processString(replacedCustom, Regex(it.getValue("match").toString()), fun(_: String) = it.getValue("replace").toString())
+    CUSTOM_MATCH_REPLACE_LIST.forEach {     // loop through custom_match_replace_list rules
+        var languages = it.getValue("languages").split(",")
+        if (LANGUAGE_CODE in languages || "all" in languages) { // if language matches the language of the rule or "all", then run it
+            replacedCustom = processString(
+                replacedCustom,
+                Regex(it.getValue("match").toString()),
+                fun(_: String) = it.getValue("replace").toString())
+        }
     }
     return "$START_SPEAK\n$replacedCustom\n$END_SPEAK"
 }

--- a/cx-phrases/src/test/kotlin/io/nuvalence/cx/tools/phrases/SsmlKtTest.kt
+++ b/cx-phrases/src/test/kotlin/io/nuvalence/cx/tools/phrases/SsmlKtTest.kt
@@ -24,6 +24,13 @@ internal class SsmlKtTest {
         assert(outputAudioTextEs.contains("languageCode"))
         assert(outputAudioTextEs.contains("g o o g l e") && outputAudioTextEs.contains("i n s u r a n c e"))
         assert(!outputAudioTextEs.contains("google") && !outputAudioTextEs.contains("insurance"))
+
+        outputAudioText = audioMessage("en", "Albany will be said normally.").toString()
+        outputAudioTextEs = audioMessage("es", "Albany spelled A-l-b-a-n-i").toString()
+        var outputAudioTextOther = audioMessage("na", "Albany spelled A-l-b-a-n-y").toString()
+        assert(outputAudioText.contains("Albany"))
+        assert(outputAudioTextEs.contains("Albani"))
+        assert(outputAudioTextOther.contains("A l b a n y"))
     }
 
     @Test
@@ -49,6 +56,10 @@ Please call <break time="300ms"/><prosody rate="90%"><say-as interpret-as="telep
 </speak>""", addSsmlTags("Please call 555-123-1234 to schedule an appointment."))
 
         assert(!addSsmlTags("Do not process 1234567890 as a telephone number").contains("<say-as interpret-as=\"telephone\">"))
+
+        assertEquals("""<speak>
+1099-G <break time="300ms"/> and 1099-G <break time="300ms"/> and 1099-G <break time="300ms"/>
+</speak>""", addSsmlTags("1099-G and 1099G and 1099 G"))
     }
 
     @Test
@@ -59,6 +70,16 @@ Please call <break time="300ms"/><prosody rate="90%"><say-as interpret-as="telep
             processUrl(" dol.ny.gov/when-to-file-a-claim"))
         assertEquals("""<break time="300ms"/><prosody rate="90%"><s><break time="100ms"/><say-as interpret-as="verbatim"> n y </say-as></s><break time="100ms"/><s><break time="100ms"/><say-as interpret-as="verbatim"> . </say-as></s><s><break time="100ms"/><say-as interpret-as="verbatim"> d o l </say-as></s><break time="100ms"/><s><break time="100ms"/><say-as interpret-as="verbatim"> . </say-as></s><s><break time="100ms"/><say-as interpret-as="verbatim"> g o v </say-as></s><break time="100ms"/><s><break time="100ms"/><say-as interpret-as="verbatim"> . </say-as></s>com<break time="100ms"/><s><break time="100ms"/><say-as interpret-as="verbatim"> / </say-as></s>1099<break time="100ms"/><s><break time="100ms"/><say-as interpret-as="verbatim"> - </say-as></s><s><break time="100ms"/><say-as interpret-as="verbatim"> G </say-as></s></prosody><break time="300ms"/>""",
             processUrl("ny.dol.gov.com/1099-G"))
+        assertEquals("""<break time="300ms"/><prosody rate="90%">unemployment<break time="100ms"/><s><break time="100ms"/><say-as interpret-as="verbatim"> . </say-as></s>labor<break time="100ms"/><s><break time="100ms"/><say-as interpret-as="verbatim"> . </say-as></s><s><break time="100ms"/><say-as interpret-as="verbatim"> n y </say-as></s><break time="100ms"/><s><break time="100ms"/><say-as interpret-as="verbatim"> . </say-as></s><s><break time="100ms"/><say-as interpret-as="verbatim"> g o v </say-as></s></prosody><break time="300ms"/>""",
+            processUrl("unemployment.labor.ny.gov"))
+
+        var processedUrl = processUrl("nys.dol.ny.gov/nysdol-po-ny-gov")
+        assert(processedUrl.contains("n y s"))
+        assert(processedUrl.contains("d o l"))
+        assert(processedUrl.contains("n y"))
+        assert(processedUrl.contains("g o v"))
+        assert(processedUrl.contains("n y s d o l"))
+        assert(processedUrl.contains("p o"))
     }
 
     @Test


### PR DESCRIPTION
- add support for language-specific match/replace rules
- add use cases from ticket (https://dol-ewf.atlassian.net/browse/UICCAI-748)
- updated tests accordingly
- updated documentation on use/purpose

To Test:
These cases should be covered by the unit test cases, but extra validation/checking can be done by writing test strings in a test case and verifying the generated ssml sounds as expected using Google's TTS API.