### PR TITLE
UICCAI-585: added agent path to test report output and spreadsheet artifact

### DIFF
--- a/cx-shared/src/main/kotlin/io/nuvalence/cx/tools/shared/SheetCopier.kt
+++ b/cx-shared/src/main/kotlin/io/nuvalence/cx/tools/shared/SheetCopier.kt
@@ -62,16 +62,6 @@ class SheetCopier(credentialsURL: URL, private val spreadsheetId: String) {
                 service.spreadsheets().batchUpdate(destinationSpreadsheetId, updateRequest).execute()
             }
 
-
-        // Delete default first sheet from destination spreadsheet
-        val firstSheetId = service.spreadsheets().get(destinationSpreadsheetId).execute().sheets?.firstOrNull()?.properties?.sheetId
-        val deleteRequest = BatchUpdateSpreadsheetRequest().setRequests(
-            listOf(Request().setDeleteSheet(
-                DeleteSheetRequest().setSheetId(firstSheetId)
-            ))
-        )
-        service.spreadsheets().batchUpdate(destinationSpreadsheetId, deleteRequest).execute()
-
         return destinationSpreadsheetId
     }
 

--- a/cx-shared/src/main/kotlin/io/nuvalence/cx/tools/shared/SheetReader.kt
+++ b/cx-shared/src/main/kotlin/io/nuvalence/cx/tools/shared/SheetReader.kt
@@ -3,6 +3,7 @@ package io.nuvalence.cx.tools.shared
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.json.gson.GsonFactory
 import com.google.api.services.sheets.v4.Sheets
+import com.google.api.services.sheets.v4.model.Sheet
 import java.net.URL
 
 /**
@@ -38,12 +39,16 @@ class SheetReader(private val credentialsURL: URL, private val spreadsheetId: St
     }
 
     fun listSheets() : List<String> {
+        return getSheets()
+            .map {sheet ->
+                sheet.properties?.title!!
+            }
+    }
+
+    fun getSheets() : List<Sheet> {
         return service.spreadsheets()
             .get(spreadsheetId)
             .execute()
             .sheets
-            .map {sheet ->
-                sheet.properties?.title!!
-            }
     }
 }

--- a/cx-shared/src/main/kotlin/io/nuvalence/cx/tools/shared/SheetWriter.kt
+++ b/cx-shared/src/main/kotlin/io/nuvalence/cx/tools/shared/SheetWriter.kt
@@ -119,7 +119,13 @@ class SheetWriter(credentialsURL: URL, private val spreadsheetId: String) {
         // Execute the batch update request
         val result = service.spreadsheets().values().batchUpdate(spreadsheetId, body).execute()
 
-        println("${result.totalUpdatedCells} cells updated.")
+        println("${result.totalUpdatedCells ?: 0} cells updated.")
+    }
+
+    fun batchUpdateSheets(requests: List<Request>) {
+        // Create a BatchUpdateSpreadsheetRequest
+        val updateRequest = BatchUpdateSpreadsheetRequest().setRequests(requests)
+        service.spreadsheets().batchUpdate(spreadsheetId, updateRequest).execute()
     }
 }
 

--- a/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/artifact/SpreadsheetArtifact.kt
+++ b/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/artifact/SpreadsheetArtifact.kt
@@ -1,8 +1,11 @@
 package io.nuvalence.cx.tools.cxtest.artifact
 
-import io.nuvalence.cx.tools.cxtest.assertion.ContextAwareAssertionError
+import com.google.api.services.sheets.v4.model.Request
+import com.google.api.services.sheets.v4.model.SheetProperties
+import com.google.api.services.sheets.v4.model.UpdateSheetPropertiesRequest
 import io.nuvalence.cx.tools.cxtest.util.PROPERTIES
 import io.nuvalence.cx.tools.shared.SheetCopier
+import io.nuvalence.cx.tools.shared.SheetReader
 import io.nuvalence.cx.tools.shared.SheetWriter
 import io.nuvalence.cx.tools.shared.UpdateRequest
 import java.net.URL
@@ -11,10 +14,13 @@ class SpreadsheetArtifact {
     companion object {
         val url = PROPERTIES.CREDENTIALS_URL.get()!!
         val spreadsheetId = PROPERTIES.SPREADSHEET_ID.get()!!
+        val agentPath = PROPERTIES.AGENT_PATH.get()!!
     }
 
     fun createArtifact(destinationTitle: String) : String {
-        return SheetCopier(URL(url), spreadsheetId).copySpreadsheet(destinationTitle)
+        val destinationSpreadsheetId = SheetCopier(URL(url), spreadsheetId).copySpreadsheet(destinationTitle)
+        updateInfoSheet(destinationSpreadsheetId)
+        return destinationSpreadsheetId
     }
 
     fun writeArtifact(spreadsheetId: String, requestData: Map<String, String>) {
@@ -22,5 +28,21 @@ class SpreadsheetArtifact {
             UpdateRequest(k, v)
         }
         return SheetWriter(URL(url), spreadsheetId).batchUpdateCells(updateRequests)
+    }
+
+    private fun updateInfoSheet(destinationSpreadsheetId: String) {
+        val title = "Test info"
+        val firstSheetId = SheetReader(URL(url), destinationSpreadsheetId, "").getSheets().firstOrNull()?.properties?.sheetId
+        val sheetWriter = SheetWriter(URL(url), destinationSpreadsheetId)
+        sheetWriter.batchUpdateSheets(listOf(
+            Request().setUpdateSheetProperties(
+                UpdateSheetPropertiesRequest().setProperties(SheetProperties().setSheetId(firstSheetId).setTitle(title)).setFields("title")
+            )))
+
+        val updateCellRequests = listOf(
+            UpdateRequest("${title}!A1", "Agent path"),
+            UpdateRequest("${title}!B1", agentPath)
+        )
+        sheetWriter.batchUpdateCells(updateCellRequests)
     }
 }

--- a/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/extension/SmokeTestExtension.kt
+++ b/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/extension/SmokeTestExtension.kt
@@ -1,5 +1,8 @@
 package io.nuvalence.cx.tools.cxtest.extension
 
+import com.google.api.services.sheets.v4.model.Request
+import com.google.api.services.sheets.v4.model.SheetProperties
+import com.google.api.services.sheets.v4.model.UpdateSheetPropertiesRequest
 import com.google.cloud.dialogflow.cx.v3beta1.SessionsClient
 import com.google.cloud.dialogflow.cx.v3beta1.SessionsSettings
 import io.nuvalence.cx.tools.cxtest.artifact.SpreadsheetArtifact
@@ -24,6 +27,7 @@ class SmokeTestExtension () : ArgumentsProvider, BeforeAllCallback, AfterAllCall
     }
 
     override fun beforeAll(context: ExtensionContext?) {
+        println("Agent: ${PROPERTIES.AGENT_PATH.get()}")
         println("Matching mode: ${PROPERTIES.MATCHING_MODE.get()}")
 
         val artifactSpreadsheetId = artifact.createArtifact("Smoke Spreadsheet ${


### PR DESCRIPTION
# Testing

Running the test framework should now include the agent path in both the test report output and spreadsheet artifact as follows:

## Test report output
<img width="917" alt="image" src="https://github.com/Nuvalence/dialogflow-cx-tools/assets/106610715/83aba002-040a-4aaf-926c-1472e58bc8b1">


## Test spreadsheet artifact
<img width="752" alt="image" src="https://github.com/Nuvalence/dialogflow-cx-tools/assets/106610715/7d804f19-89ea-49f0-997d-b7769b602ad0">
