### PR TITLE
UICCAI-587: assertions changed to assert on outputAudioText SSML

### DIFF
--- a/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/assertion/Assertions.kt
+++ b/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/assertion/Assertions.kt
@@ -39,7 +39,7 @@ fun assertFuzzyMatch(input: String, expected: String, actual: List<ResponseMessa
     val expectedRatio = PROPERTIES.MATCHING_RATIO.get()!!.toInt()
 
     val newActual = actual.joinToString("\n") { responseMessage ->
-        if (responseMessage.text.textCount > 0) responseMessage.text.getText(0); else ""
+        if (responseMessage.outputAudioText.hasSsml()) responseMessage.outputAudioText.ssml; else ""
     }.let { stripSsml(it) }
 
     matchingMode.assertFuzzyMatchString(input, expected, newActual, expectedRatio)


### PR DESCRIPTION
Tested with the following matching modes:

Normal:
[test.zip](https://github.com/Nuvalence/dialogflow-cx-tools/files/12612718/test.zip)

Adaptive:
[test_adaptive.zip](https://github.com/Nuvalence/dialogflow-cx-tools/files/12612727/test_adaptive.zip)
