### PR TITLE
UICCAI-748: fix pronunciations, percentage match regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,4 @@ Please refer to the README.md files under `cx-large` and `cx-variations` for add
 # Contributors
 * https://github.com/aantenangeli
 * https://github.com/gteng-nuvalence
+* https://github.com/nuvalencenate

--- a/cx-phrases/defaults.conf
+++ b/cx-phrases/defaults.conf
@@ -2,7 +2,7 @@
     URL_SEPARATORS: [ "#", "/", ".", "_", "-" ]
     MATCH_URL_REGEX: "\\s\\w+\\.\\w+(?:[.\\/\\-]\\w+)*\\b"
     MATCH_PHONE_REGEX: "\\b(\\d{3}-\\d{3}-\\d{4})\\b"
-    MATCH_PERCENTAGE_REGEX: "\\b\\d+(\\.\\d+)*\\s*%(?!\"|<)\\B"
+    MATCH_PERCENTAGE_REGEX: "\\b\\d+((\\.|,)\\d+)*\\s*%(?!\"|<)\\B"
     MATCH_NUMBERS_REGEX: "\\b(?<!\\d{3}-\\d{3}-)\\b\\d+\\b(?!-\\d{3}-\\d{4})(?!-\\d{1,4})(?!%\">|:|-|\\s[Gg])\\b"
     SHORT_TOKEN_WHITELIST: [ "com", "org" ]
     INVALID_CONSONANT_SEQUENCE: "\\b.*([^aeiouy]{5,}|[^aeiou][^aeiouy]{4,}[^aeiou]|[hjmnqvwxz]r|[cdfghjqvwxz]s|[dhjmnqrtvxwz]l|sth|kpy|ww|hh|jj|kk|qq|vv|xx).*\\b"
@@ -23,6 +23,31 @@
         match: "1099(-){0,1}\\s*[Gg]\\s*",
         replace: "1099-G <break time=\"300ms\"/> "
 
+    }, {
+        # reformat "partialui" so it is pronounced "partial you eye" rather than "partial ooo eee"
+        languages: "en",
+        match: "partialui",
+        replace: "partial U I "
+    }, {
+        # make PIN lowercase so it is read as the word pin and not the letters
+        languages: "en",
+        match: "PIN",
+        replace: "pin "
+    }, {
+        # space out DOL so it is read as the letters in all languages
+        languages: "all",
+        match: "DOL",
+        replace: "D O L "
+    }, {
+        # replace NY in non-English languages with N Y
+        languages: "all",
+        match: ", NY\\s*",
+        replace: ", N Y "
+    }, {
+        # replace NY in English addresses with New York
+        languages: "en",
+        match: ", N Y\\s*",
+        replace: ", New York "
     }, {
         # spell out "Albany" for all languages except English
         languages: "all",

--- a/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/Ssml.kt
+++ b/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/Ssml.kt
@@ -166,7 +166,7 @@ fun processUrl(url: String) =
                     else // Otherwise we spell it. Stupid say-as verbatim or character not always work...
                         "$START_SAY_VERBATIM ${token.map { it }.joinToString(" ")} $END_SAY_VERBATIM"
                 } else {
-                    if (token.contains(INVALID_CONSONANT_SEQUENCE) || token in URL_VERBATIM_TOKENS) // If the token has weird consonant sequences or is specifically listed in our spelling dictionary, spell it
+                    if (token.contains(INVALID_CONSONANT_SEQUENCE) || token.lowercase() in URL_VERBATIM_TOKENS) // If the token has weird consonant sequences or is specifically listed in our spelling dictionary, spell it
                         "$START_SAY_VERBATIM ${token.map { it }.joinToString(" ")} $END_SAY_VERBATIM"
                     else
                         token


### PR DESCRIPTION
Changes include:
- fix for percentages to match numbers using , instead of . as decimal
- fix pronunciations of `DOL` (changed to `D O L`), `PIN` (changed to `pin`), `partialui` (changed to `partial U I`), and `NY` in addresses (changed to `N Y` in other languages and `New York` in English)