### PR TITLE
UICCAI-861: added DFCX Test Builder spec, refactors

### DIFF
--- a/cx-test/build.gradle.kts
+++ b/cx-test/build.gradle.kts
@@ -70,8 +70,8 @@ val testTask = tasks.withType<Test> {
             println("Including tags $includeTagsProperty")
             includeTags(includeTagsProperty)
         } else {
-            println("Defaulting to both e2e and smoke")
-            includeTags("e2e|smoke")
+            println("Defaulting to dfcx")
+            includeTags("dfcx")
         }
 
         if (excludeTagsProperty?.isNotBlank() == true) {

--- a/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/DFCXTestBuilderSpec.kt
+++ b/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/DFCXTestBuilderSpec.kt
@@ -1,0 +1,88 @@
+package io.nuvalence.cx.tools.cxtest
+
+import com.google.cloud.dialogflow.cx.v3.*
+import io.nuvalence.cx.tools.cxtest.extension.DFCXTestBuilderExtension
+import io.nuvalence.cx.tools.cxtest.model.DFCXTestBuilderResult
+import io.nuvalence.cx.tools.cxtest.model.DFCXTestBuilderResultStep
+import io.nuvalence.cx.tools.cxtest.model.ResultLabel
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+import kotlin.AssertionError
+
+@Execution(ExecutionMode.CONCURRENT)
+@Tag("dfcx")
+@ExtendWith(DFCXTestBuilderExtension::class)
+class DFCXTestBuilderSpec {
+    companion object {
+        val formattedResult: ThreadLocal<DFCXTestBuilderResult> = ThreadLocal()
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @ArgumentsSource(DFCXTestBuilderExtension::class)
+    fun testCases(displayName: String, testCase: TestCase, testCaseResult: TestCaseResult) {
+        val testBuilderResult = DFCXTestBuilderResult(
+            testCaseId = testCase.name,
+            testCaseName = testCase.displayName,
+            tags = testCase.tagsList.map { tag -> tag.toString() },
+            note = testCase.notes
+        )
+        formattedResult.set(testBuilderResult)
+
+        val fullResult = DFCXTestBuilderExtension.testClient.getTestCaseResult(testCaseResult.name)
+
+        fullResult.conversationTurnsList.forEachIndexed { index, turn ->
+            val resultStep = DFCXTestBuilderResultStep(
+                userInput = turn.userInput.input.text.text,
+                expectedAgentOutput = testCase.testCaseConversationTurnsList[index].virtualAgentOutput.textResponsesList.joinToString("\n") { responseMessage ->
+                    responseMessage.textList.reduce { acc, text -> acc + text }
+                },
+                actualAgentOutput = turn.virtualAgentOutput.textResponsesList.joinToString("\n") { responseMessage ->
+                    responseMessage.textList.reduce { acc, text -> acc + text }
+                },
+                expectedPage = testCase.testCaseConversationTurnsList[index].virtualAgentOutput.currentPage.displayName,
+                actualPage = turn.virtualAgentOutput.currentPage.displayName
+            )
+
+            val isStepWarn = turn.virtualAgentOutput.differencesList.any { diff ->
+                diff.type == TestRunDifference.DiffType.UTTERANCE
+            }
+
+            val isStepError = turn.virtualAgentOutput.differencesList.any { diff ->
+                diff.type == TestRunDifference.DiffType.PAGE
+            }
+
+            if (isStepError) {
+                resultStep.result = ResultLabel.FAIL
+            } else if (isStepWarn) {
+                resultStep.result = ResultLabel.WARN
+            }
+
+            testBuilderResult.resultSteps.add(resultStep)
+        }
+
+        val isTestWarn = testBuilderResult.resultSteps.any { resultStep ->
+            resultStep.result == ResultLabel.WARN
+        }
+
+        val isTestError = testBuilderResult.resultSteps.any { resultStep ->
+            resultStep.result == ResultLabel.FAIL
+        }
+
+        if (isTestError) {
+            testBuilderResult.result = ResultLabel.FAIL
+        } else if (isTestWarn) {
+            testBuilderResult.result = ResultLabel.WARN
+        }
+
+
+        if (testCaseResult.testResult == TestResult.FAILED) {
+            testBuilderResult.result = ResultLabel.FAIL
+            Assertions.fail<AssertionError>("Test failed")
+        }
+    }
+}

--- a/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/E2ESpec.kt
+++ b/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/E2ESpec.kt
@@ -2,7 +2,7 @@ package io.nuvalence.cx.tools.cxtest
 
 import com.google.cloud.dialogflow.cx.v3beta1.*
 import io.nuvalence.cx.tools.cxtest.orchestrator.OrchestratedTestMap
-import io.nuvalence.cx.tools.cxtest.sheetformat.E2EFormatReader
+import io.nuvalence.cx.tools.cxtest.testsource.E2EFormatReader
 import io.nuvalence.cx.tools.cxtest.util.PROPERTIES
 import io.nuvalence.cx.tools.cxtest.assertion.assertFuzzyMatch
 import org.junit.jupiter.api.DynamicTest

--- a/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/extension/DFCXTestBuilderExtension.kt
+++ b/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/extension/DFCXTestBuilderExtension.kt
@@ -1,0 +1,67 @@
+package io.nuvalence.cx.tools.cxtest.extension
+
+import com.google.cloud.dialogflow.cx.v3.*
+import io.nuvalence.cx.tools.cxtest.DFCXTestBuilderSpec
+import io.nuvalence.cx.tools.cxtest.testsource.DFCXTestBuilderTestSource
+import io.nuvalence.cx.tools.cxtest.util.PROPERTIES
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import java.util.*
+import java.util.stream.Stream
+
+class DFCXTestBuilderExtension () : ArgumentsProvider, BeforeAllCallback, AfterAllCallback, AfterTestExecutionCallback {
+    companion object {
+        lateinit var testClient: TestCasesClient
+    }
+
+    override fun beforeAll(context: ExtensionContext?) {
+        println("Agent: ${PROPERTIES.AGENT_PATH.get()}")
+
+        // TODO: Create artifact spreadsheet
+
+        testClient = TestCasesClient.create(
+            TestCasesSettings.newBuilder()
+                .setEndpoint(PROPERTIES.DFCX_ENDPOINT.get())
+                .build())
+
+        val testCaseList = DFCXTestBuilderTestSource().getTestScenarios()
+
+        val request: BatchRunTestCasesRequest = BatchRunTestCasesRequest.newBuilder()
+            .setParent(PROPERTIES.AGENT_PATH.get())
+            .addAllTestCases(testCaseList.map { testCase -> testCase.name })
+            .build()
+
+        val response = testClient.batchRunTestCasesAsync(request).get()
+        val resultsList = response.resultsList.sortedBy { result -> result.name }
+
+        context?.root?.getStore(ExtensionContext.Namespace.GLOBAL)?.put("testCaseEntries", testCaseList zip resultsList)
+    }
+
+    override fun afterTestExecution(context: ExtensionContext?) {
+        val result = DFCXTestBuilderSpec.formattedResult.get()
+
+        if (result != null) {
+            println(result)
+            DFCXTestBuilderSpec.formattedResult.remove()
+        }
+    }
+
+    override fun afterAll(context: ExtensionContext?) {
+        // TODO: create
+        testClient.close()
+    }
+
+    override fun provideArguments(context: ExtensionContext?): Stream<out Arguments?> {
+        val testCaseEntries = context?.root?.getStore(ExtensionContext.Namespace.GLOBAL)?.get("testCaseEntries") as List<Pair<TestCase, TestCaseResult>>
+
+        val testCaseArgs = testCaseEntries.map { (testCase, testCaseResult) ->
+            Arguments.of(testCase.displayName, testCase, testCaseResult)
+        }
+
+        return Stream.of(*testCaseArgs.toTypedArray())
+    }
+}

--- a/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/extension/SmokeTestExtension.kt
+++ b/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/extension/SmokeTestExtension.kt
@@ -1,16 +1,12 @@
 package io.nuvalence.cx.tools.cxtest.extension
 
-import com.google.api.services.sheets.v4.model.Request
-import com.google.api.services.sheets.v4.model.SheetProperties
-import com.google.api.services.sheets.v4.model.UpdateSheetPropertiesRequest
 import com.google.cloud.dialogflow.cx.v3beta1.SessionsClient
 import com.google.cloud.dialogflow.cx.v3beta1.SessionsSettings
 import io.nuvalence.cx.tools.cxtest.artifact.SpreadsheetArtifact
 import io.nuvalence.cx.tools.cxtest.assertion.ContextAwareAssertionError
 import io.nuvalence.cx.tools.cxtest.orchestrator.OrchestratedTestMap
-import io.nuvalence.cx.tools.cxtest.sheetformat.SmokeFormatReader
+import io.nuvalence.cx.tools.cxtest.testsource.SmokeFormatReader
 import io.nuvalence.cx.tools.cxtest.util.PROPERTIES
-import io.nuvalence.cx.tools.shared.SheetReader
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.params.provider.Arguments

--- a/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/model/DFCXTestBuilderResult.kt
+++ b/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/model/DFCXTestBuilderResult.kt
@@ -1,0 +1,44 @@
+package io.nuvalence.cx.tools.cxtest.model
+
+enum class ResultLabel(private val value: String) {
+    PASS("PASS"),
+    WARN("WARN"),
+    FAIL("FAIL");
+
+    override fun toString(): String {
+        return value
+    }
+}
+
+data class DFCXTestBuilderResultStep(
+    val userInput: String,
+    val expectedAgentOutput: String,
+    val actualAgentOutput: String,
+    val expectedPage: String,
+    val actualPage: String,
+    var result: ResultLabel
+) {
+    constructor (userInput: String, expectedAgentOutput: String, actualAgentOutput: String, expectedPage: String, actualPage: String):
+        this(userInput, expectedAgentOutput, actualAgentOutput, expectedPage, actualPage, ResultLabel.PASS)
+
+    override fun toString(): String {
+        return "Step result: $result\nUser Input: $userInput \nExpected Agent Output: $expectedAgentOutput\nActual Agent Output: $actualAgentOutput\nExpected Page: $expectedPage\nActual Page: $actualPage\n"
+    }
+}
+
+data class DFCXTestBuilderResult(
+    val testCaseId: String,
+    val testCaseName: String,
+    val tags: List<String>,
+    val note: String,
+    var result: ResultLabel,
+    val resultSteps: MutableList<DFCXTestBuilderResultStep>
+) {
+    constructor (testCaseId: String, testCaseName: String, tags: List<String>, note: String) :
+        this(testCaseId, testCaseName, tags, note,
+            ResultLabel.PASS, mutableListOf<DFCXTestBuilderResultStep>())
+
+    override fun toString(): String {
+        return "Test Case Name: $testCaseName, Result: $result, Result Steps:\n${resultSteps.joinToString("\n"){ resultStep -> resultStep.toString() }}"
+    }
+}

--- a/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/testsource/DFCXTestBuilderTestSource.kt
+++ b/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/testsource/DFCXTestBuilderTestSource.kt
@@ -1,0 +1,30 @@
+package io.nuvalence.cx.tools.cxtest.testsource
+
+import com.google.cloud.dialogflow.cx.v3.ListTestCasesRequest
+import com.google.cloud.dialogflow.cx.v3.TestCase
+import io.nuvalence.cx.tools.cxtest.extension.DFCXTestBuilderExtension
+import io.nuvalence.cx.tools.cxtest.util.PROPERTIES
+import java.util.*
+
+class DFCXTestBuilderTestSource {
+    fun getTestScenarios(): MutableList<TestCase> {
+        val listTestCasesRequest = ListTestCasesRequest.newBuilder()
+            .setParent(PROPERTIES.AGENT_PATH.get())
+            .setView(ListTestCasesRequest.TestCaseView.FULL)
+            .setPageSize(20)
+            .build()
+
+        val testCasesResponse = DFCXTestBuilderExtension.testClient.listTestCases(listTestCasesRequest)
+        val testCaseList = Collections.synchronizedList(mutableListOf<TestCase>())
+
+        testCasesResponse.iteratePages().forEach { page ->
+            testCaseList.addAll(page.response.testCasesList)
+        }
+        testCaseList.sortBy { testCase -> testCase.name }
+
+        // TODO: filter on tags
+
+        println("Found ${testCaseList.size} tests")
+        return testCaseList
+    }
+}

--- a/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/testsource/E2EFormatReader.kt
+++ b/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/testsource/E2EFormatReader.kt
@@ -1,4 +1,4 @@
-package io.nuvalence.cx.tools.cxtest.sheetformat
+package io.nuvalence.cx.tools.cxtest.testsource
 
 import io.nuvalence.cx.tools.cxtest.model.TestScenario
 import io.nuvalence.cx.tools.cxtest.model.TestStep

--- a/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/testsource/FormatReader.kt
+++ b/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/testsource/FormatReader.kt
@@ -1,4 +1,4 @@
-package io.nuvalence.cx.tools.cxtest.sheetformat
+package io.nuvalence.cx.tools.cxtest.testsource
 
 import io.nuvalence.cx.tools.cxtest.model.TestScenario
 

--- a/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/testsource/SmokeFormatReader.kt
+++ b/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/testsource/SmokeFormatReader.kt
@@ -1,4 +1,4 @@
-package io.nuvalence.cx.tools.cxtest.sheetformat
+package io.nuvalence.cx.tools.cxtest.testsource
 
 import io.nuvalence.cx.tools.cxtest.model.TestScenario
 import io.nuvalence.cx.tools.cxtest.model.TestStep

--- a/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/util/Properties.kt
+++ b/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/util/Properties.kt
@@ -1,5 +1,15 @@
 package io.nuvalence.cx.tools.cxtest.util
 
+private fun getRegionalDFCXEndpoint(agentPath: String): String {
+    val base = "dialogflow.googleapis.com:443"
+    val (_, _, _, location) = agentPath.split("/")
+    return if (location == "global") {
+        base
+    } else {
+        "${location}-${base}"
+    }
+}
+
 enum class PROPERTIES(private val value: String) {
     ORCHESTRATION_MODE("orchestrationMode"),
     MATCHING_MODE("matchingMode"),
@@ -13,7 +23,7 @@ enum class PROPERTIES(private val value: String) {
     SPREADSHEET_ID("spreadsheetId"),
     DFCX_ENDPOINT("dfcxEndpoint") {
         override fun get(): String {
-            return super.get().takeIf { prop -> !prop.isNullOrEmpty() } ?: "dialogflow.googleapis.com:443"
+            return super.get().takeIf { prop -> !prop.isNullOrEmpty() } ?: getRegionalDFCXEndpoint(AGENT_PATH.get()!!)
         }
     };
 

--- a/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/util/Properties.kt
+++ b/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/util/Properties.kt
@@ -13,7 +13,7 @@ enum class PROPERTIES(private val value: String) {
     SPREADSHEET_ID("spreadsheetId"),
     DFCX_ENDPOINT("dfcxEndpoint") {
         override fun get(): String {
-            return super.get().takeIf { prop -> !prop.isNullOrEmpty() } ?: "us-east1-dialogflow.googleapis.com:443"
+            return super.get().takeIf { prop -> !prop.isNullOrEmpty() } ?: "dialogflow.googleapis.com:443"
         }
     };
 


### PR DESCRIPTION
## Describe your changes
* Added DFCX Test Builder spec and corresponding scaffolding
  * Added test source to procure (and later filter) test cases
  * Added test extension to handle beforeAll handler (test procurement and kickoff), afterEach handler (test result handling, and later persistence in memory), afterAll handler (resource cleanup), and argument provision for test run
  * Added test builder result model to support extended test result information (for later persistence in artifact spreadsheet)
* Changed default test run to dfcx spec
* Refactored sheetreaders into testsource package for consistency 

## Issue ticket number and link

https://dol-ewf.atlassian.net/browse/UICCAI-861

## Agent Link and Description of How to Test Changes

https://dialogflow.cloud.google.com/cx/projects/dol-uisim-ccai-dev-app/locations/global/agents/997f91c8-6a5b-4852-9621-f933faa7fa13

Run the following command:
```
./gradlew cx-test:test --info -PagentPath="projects/dol-uisim-ccai-dev-app/locations/global/agents/997f91c8-6a5b-4852-9621-f933faa7fa13"
```

Testing DFCX endpoint autofill for non-global locations:
```
./gradlew cx-test:test --info -PagentPath="projects/dol-uisim-ccai-dev-app/locations/us-east1/agents/69f4c039-9f4b-4879-bc33-806bbface6ba"
```

Agent ID can be replaced accordingly in command: `.../agents/<agentId>`

## Checklist before requesting a review
- [x] I have performed a self-review of my changes
