### PR TITLE
UICCAI-865: add DFCX test tags

### DIFF
--- a/cx-test/README.md
+++ b/cx-test/README.md
@@ -133,8 +133,9 @@ Determines which tests should be run, based on their tags.
 - Options:
   - e2e: End-to-end tests.
   - smoke: Smoke tests.
-- Usage: `-PincludeTags="e2e|smoke"`
-- Default if not supplied: `"e2e|smoke"` (runs both)
+  - dfcx: DFCX Test Builder tests.
+- Usage: `-PincludeTags="e2e|smoke|dfcx"`
+- Default if not supplied: `"dfcx"`
 
 #### Exclude Tags
 
@@ -143,5 +144,16 @@ Determines which tests should not be run, based on their tags.
 - Options:
   - e2e: End-to-end tests.
   - smoke: Smoke tests.
-- Usage: `-PexcludeTags="e2e|smoke"`
+  - dfcx: DFCX Test Builder tests.
+- Usage: `-PexcludeTags="e2e|smoke|dfcx"`
 - Default if not supplied: nothing
+
+#### DFCX Tag Filter
+
+Determines which tests should be run, based on the associated tags on the test. Used exclusively for the DFCX Test Builder Spec.
+
+- Options:
+    - `"ALL"`: runs all tests associated with the agent
+    - `"#Filter1,#Filter2,..."`: runs all tests that include all tags contained within the comma-separated expression
+- Usage: `-dfcxTagFilter="#Filter1,#Filter2"`
+- Default if not supplied: `"ALL"`

--- a/cx-test/build.gradle.kts
+++ b/cx-test/build.gradle.kts
@@ -51,7 +51,7 @@ val postProcessTestReport = tasks.register<DefaultTask>("postProcessTestReport")
 }
 
 val testTask = tasks.withType<Test> {
-    val properties = listOf("agentPath", "spreadsheetId", "credentialsUrl", "orchestrationMode", "matchingMode", "matchingRatio", "dfcxEndpoint")
+    val properties = listOf("agentPath", "spreadsheetId", "dfcxTagFilter", "credentialsUrl", "orchestrationMode", "matchingMode", "matchingRatio", "dfcxEndpoint")
     systemProperties(project.properties.filter { (key, _) -> key in properties })
 
     useJUnitPlatform {

--- a/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/testsource/DFCXTestBuilderTestSource.kt
+++ b/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/testsource/DFCXTestBuilderTestSource.kt
@@ -7,7 +7,7 @@ import io.nuvalence.cx.tools.cxtest.util.PROPERTIES
 import java.util.*
 
 class DFCXTestBuilderTestSource {
-    fun getTestScenarios(): MutableList<TestCase> {
+    fun getTestScenarios(): List<TestCase> {
         val listTestCasesRequest = ListTestCasesRequest.newBuilder()
             .setParent(PROPERTIES.AGENT_PATH.get())
             .setView(ListTestCasesRequest.TestCaseView.FULL)
@@ -22,7 +22,18 @@ class DFCXTestBuilderTestSource {
         }
         testCaseList.sortBy { testCase -> testCase.name }
 
-        // TODO: filter on tags
+        val tagFilter = PROPERTIES.DFCX_TAG_FILTER.get()!!
+
+        if (tagFilter != "ALL") {
+            val tagFilters = tagFilter.split(',')
+
+            val filteredTestCaseList = testCaseList.filter { testCase ->
+                testCase.tagsList.containsAll(tagFilters)
+            }
+
+            println("Found ${filteredTestCaseList.size} tests")
+            return filteredTestCaseList
+        }
 
         println("Found ${testCaseList.size} tests")
         return testCaseList

--- a/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/util/Properties.kt
+++ b/cx-test/src/test/kotlin/io/nuvalence/cx/tools/cxtest/util/Properties.kt
@@ -15,6 +15,11 @@ enum class PROPERTIES(private val value: String) {
         override fun get(): String {
             return super.get().takeIf { prop -> !prop.isNullOrEmpty() } ?: "dialogflow.googleapis.com:443"
         }
+    },
+    DFCX_TAG_FILTER("dfcxTagFilter") {
+        override fun get(): String {
+            return super.get().takeIf { prop -> !prop.isNullOrEmpty() } ?: "ALL"
+        }
     };
 
     open fun get(): String? {


### PR DESCRIPTION
## Describe your changes
* Added tag filtering to DFCX Test Builder spec
  * Behavior outlined in readme

## Issue ticket number and link

https://dol-ewf.atlassian.net/browse/UICCAI-865

## Agent Link and Description of How to Test Changes

https://dialogflow.cloud.google.com/cx/projects/dol-uisim-ccai-dev-app/locations/global/agents/7d8acdfb-e622-4b98-bcd0-3ba2a92fde4e

Run the following commands:

Default test:
```
./gradlew cx-test:test --info -PagentPath="projects/dol-uisim-ccai-dev-app/locations/global/agents/7d8acdfb-e622-4b98-bcd0-3ba2a92fde4e" 
```

All test:
```
./gradlew cx-test:test --info -PagentPath="projects/dol-uisim-ccai-dev-app/locations/global/agents/7d8acdfb-e622-4b98-bcd0-3ba2a92fde4e" -PdfcxTagFilter="ALL"
```

Filter test:
```
./gradlew cx-test:test --info -PagentPath="projects/dol-uisim-ccai-dev-app/locations/global/agents/7d8acdfb-e622-4b98-bcd0-3ba2a92fde4e" -PdfcxTagFilter="#Block1,#PersonalInfo,#OC,#EN"
```

Agent ID can be replaced accordingly in command: `.../agents/<agentId>`

## Checklist before requesting a review
- [x] I have performed a self-review of my changes
