### PR TITLE
UICCAI-1034: add support for wrapping parameters in SSML

### DIFF
--- a/cx-phrases/defaults.conf
+++ b/cx-phrases/defaults.conf
@@ -18,11 +18,25 @@
         match: "\\$session.params.recent-year",
         replace: "<say-as interpret-as=\"date\" format=\"yyyy\">$session.params.recent-year</say-as>"
     }, {
+        # wrap $session.params.data-collection-dmv-id with SSML so it is pronounced correctly
+        languages: "all",
+        match: "\\$session.params.data-collection-dmv-id",
+        replace: "<say-as interpret-as=\"verbatim\">$session.params.data-collection-dmv-id</say-as>"
+    }, {
+        # wrap $session.params.data-collection-dmv-doc-id with SSML so it is pronounced correctly
+        languages: "all",
+        match: "\\$session.params.data-collection-dmv-doc-id",
+        replace: "<say-as interpret-as=\"verbatim\">$session.params.data-collection-dmv-doc-id</say-as>"
+    }, {
+        # wrap DD214 with SSML to pronounce correctly
+        languages: "all",
+        match: "[dD][dD]-*214",
+        replace: "<say-as interpret-as=\"verbatim\">DD214</say-as>"
+    }, {
         # add break time after 1099-G it reads naturally
         languages: "en",
         match: "1099(-){0,1}\\s*[Gg]\\s*",
         replace: "1099-G <break time=\"300ms\"/> "
-
     }, {
         # reformat "partialui" so it is pronounced "partial you eye" rather than "partial ooo eee"
         languages: "en",

--- a/cx-phrases/defaults.conf
+++ b/cx-phrases/defaults.conf
@@ -1,7 +1,7 @@
 {
     URL_SEPARATORS: [ "#", "/", ".", "_", "-" ]
     MATCH_URL_REGEX: "\\s\\w+\\.\\w+(?:[.\\/\\-]\\w+)*\\b"
-    MATCH_PHONE_REGEX: "\\b(\\d{3}-\\d{3}-\\d{4})\\b"
+    MATCH_PHONE_REGEX: "(\\b(\\d{3}-\\d{3}-\\d{4})\\b)|(\\$.*phone-number.*?)\\s"
     MATCH_PERCENTAGE_REGEX: "\\b\\d+((\\.|,)\\d+)*\\s*%(?!\"|<)\\B"
     MATCH_NUMBERS_REGEX: "\\b(?<!\\d{3}-\\d{3}-)\\b\\d+\\b(?!-\\d{3}-\\d{4})(?!-\\d{1,4})(?!%\">|:|-|\\s[Gg])\\b"
     SHORT_TOKEN_WHITELIST: [ "com", "org" ]

--- a/cx-phrases/defaults.conf
+++ b/cx-phrases/defaults.conf
@@ -1,7 +1,7 @@
 {
     URL_SEPARATORS: [ "#", "/", ".", "_", "-" ]
     MATCH_URL_REGEX: "\\s\\w+\\.\\w+(?:[.\\/\\-]\\w+)*\\b"
-    MATCH_PHONE_REGEX: "(\\b(\\d{3}-\\d{3}-\\d{4})\\b)|(\\$.*phone-number.*?)\\s"
+    MATCH_PHONE_REGEX: "(\\b(\\d{3}-\\d{3}-\\d{4})\\b)|\\$(session\\.params|flow)\\.[^.]*?phone-number[^.]*?(?=[\\.\\,!?]*\\s)"
     MATCH_PERCENTAGE_REGEX: "\\b\\d+((\\.|,)\\d+)*\\s*%(?!\"|<)\\B"
     MATCH_NUMBERS_REGEX: "\\b(?<!\\d{3}-\\d{3}-)\\b\\d+\\b(?!-\\d{3}-\\d{4})(?!-\\d{1,4})(?!%\">|:|-|\\s[Gg])\\b"
     SHORT_TOKEN_WHITELIST: [ "com", "org" ]

--- a/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/Ssml.kt
+++ b/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/Ssml.kt
@@ -199,7 +199,7 @@ fun processPercentage(number: String) =
 fun processPhone(number: String) =
     START_PROSODY_RATE + // Pause and talk slowly
         """<say-as interpret-as="telephone" google:style="zero-as-zero">""" +
-            number + END_SAY + END_PROSODY_RATE
+            number.trimEnd() + END_SAY + END_PROSODY_RATE + " "
 
 /**
  * Splits a URL in its basic components, including the separators (e.g. . or /)

--- a/cx-phrases/src/test/kotlin/io/nuvalence/cx/tools/phrases/SsmlKtTest.kt
+++ b/cx-phrases/src/test/kotlin/io/nuvalence/cx/tools/phrases/SsmlKtTest.kt
@@ -52,8 +52,12 @@ To request information or records, follow the instructions outlined at<break tim
 </speak>""", addSsmlTags("To request information or records, follow the instructions outlined at on.ny.gov/dcfaq ."))
 
         assertEquals("""<speak>
-Please call <break time="300ms"/><prosody rate="90%"><say-as interpret-as="telephone" google:style="zero-as-zero">800-833-3000</say-as></prosody><break time="300ms"/>to schedule an appointment.
+Please call <break time="300ms"/><prosody rate="90%"><say-as interpret-as="telephone" google:style="zero-as-zero">800-833-3000</say-as></prosody><break time="300ms"/> to schedule an appointment.
 </speak>""", addSsmlTags("Please call 800-833-3000 to schedule an appointment."))
+
+        assertEquals("""<speak>
+Call <break time="300ms"/><prosody rate="90%"><say-as interpret-as="telephone" google:style="zero-as-zero">123-123-1234</say-as></prosody><break time="300ms"/>  or <break time="300ms"/><prosody rate="90%"><say-as interpret-as="telephone" google:style="zero-as-zero">""" + '$'.toString() + """flow.test-phone-number-var'</say-as></prosody><break time="300ms"/> to get in touch.
+</speak>""", addSsmlTags("Call 123-123-1234 or " + '$'.toString() + "flow.test-phone-number-var' to get in touch."))
 
         assert(!addSsmlTags("Do not process 1234567890 as a telephone number").contains("<say-as interpret-as=\"telephone\">"))
 
@@ -93,7 +97,7 @@ Please call <break time="300ms"/><prosody rate="90%"><say-as interpret-as="telep
 
     @Test
     fun testProcessPhone() {
-        var ssmlPhone = """<break time="300ms"/><prosody rate="90%"><say-as interpret-as="telephone" google:style="zero-as-zero">123-456-7890</say-as></prosody><break time="300ms"/>"""
+        var ssmlPhone = """<break time="300ms"/><prosody rate="90%"><say-as interpret-as="telephone" google:style="zero-as-zero">123-456-7890</say-as></prosody><break time="300ms"/> """
         assertEquals(ssmlPhone, processPhone("123-456-7890"))
     }
 


### PR DESCRIPTION
Since parameters are not interpreted until "runtime" (say-time?), some don't get proper SSML around them and they are pronounced weird. This adds parameters with `phone-number` in them to the phone-number regex, allowing it to be interpreted correctly, as well as manually adding regex matching for `dmv-id`, `dmv-doc-id` and "DD214" to pronounce those strings correctly.