### PR TITLE
UICCAI-1061: ignore numbers less than 4 characters in length for ssml processing

### DIFF
--- a/cx-phrases/defaults.conf
+++ b/cx-phrases/defaults.conf
@@ -16,22 +16,22 @@
         # wrap $session.params.recent-year with SSML so it is pronounced correctly
         languages: "all",
         match: "\\$session.params.recent-year",
-        replace: "<say-as interpret-as=\"date\" format=\"yyyy\">$session.params.recent-year</say-as>"
+        replace: "<say-as interpret-as=\"date\" format=\"yyyy\">$session.params.recent-year</say-as> "
     }, {
         # wrap $session.params.data-collection-dmv-id with SSML so it is pronounced correctly
         languages: "all",
         match: "\\$session.params.data-collection-dmv-id",
-        replace: "<say-as interpret-as=\"verbatim\">$session.params.data-collection-dmv-id</say-as>"
+        replace: "<say-as interpret-as=\"verbatim\">$session.params.data-collection-dmv-id</say-as> "
     }, {
         # wrap $session.params.data-collection-dmv-doc-id with SSML so it is pronounced correctly
         languages: "all",
         match: "\\$session.params.data-collection-dmv-doc-id",
-        replace: "<say-as interpret-as=\"verbatim\">$session.params.data-collection-dmv-doc-id</say-as>"
+        replace: "<say-as interpret-as=\"verbatim\">$session.params.data-collection-dmv-doc-id</say-as> "
     }, {
         # wrap DD214 with SSML to pronounce correctly
         languages: "all",
         match: "[dD][dD]-*214",
-        replace: "<say-as interpret-as=\"verbatim\">DD214</say-as>"
+        replace: "<say-as interpret-as=\"verbatim\">DD214</say-as> "
     }, {
         # add break time after 1099-G it reads naturally
         languages: "en",

--- a/cx-phrases/defaults.conf
+++ b/cx-phrases/defaults.conf
@@ -38,6 +38,10 @@
         match: "1099(-){0,1}\\s*[Gg]\\s*",
         replace: "1099-G <break time=\"300ms\"/> "
     }, {
+        languages: "en",
+        match: "\\s4320",
+        replace: " <say-as interpret-as=\"verbatim\">4320</say-as> "
+    }, {
         # reformat "partialui" so it is pronounced "partial you eye" rather than "partial ooo eee"
         languages: "en",
         match: "partialui",

--- a/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/Ssml.kt
+++ b/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/Ssml.kt
@@ -179,7 +179,7 @@ fun processUrl(url: String) =
 
 fun processNumber(number: String) =
     // if a number has more than 3 digits, say one digit at a time, and make sure we say "zero", not "oh"
-    (if (number.length > 3)
+    (if (number.length > 4)
         START_PROSODY_RATE + START_SAY_VERBATIM + number + END_SAY_VERBATIM + END_PROSODY_RATE
     else
         number

--- a/cx-phrases/src/test/kotlin/io/nuvalence/cx/tools/phrases/SsmlKtTest.kt
+++ b/cx-phrases/src/test/kotlin/io/nuvalence/cx/tools/phrases/SsmlKtTest.kt
@@ -90,8 +90,8 @@ Call <break time="300ms"/><prosody rate="90%"><say-as interpret-as="telephone" g
     fun testProcessNumber() {
         var ssmlNumber = """<break time="300ms"/><prosody rate="90%"><s><break time="100ms"/><say-as interpret-as="verbatim">123450</say-as></s></prosody><break time="300ms"/>"""
         assertEquals(ssmlNumber, processNumber("123450"))
-        var ssmlNumberNormal = """<break time="300ms"/><prosody rate="90%"><s><break time="100ms"/><say-as interpret-as="verbatim">1564</say-as></s></prosody><break time="300ms"/>"""
-        assertEquals(ssmlNumberNormal, processNumber("1564"))
+        var ssmlNumberNormal = """<break time="300ms"/><prosody rate="90%"><s><break time="100ms"/><say-as interpret-as="verbatim">15645</say-as></s></prosody><break time="300ms"/>"""
+        assertEquals(ssmlNumberNormal, processNumber("15645"))
         assertEquals("800", processNumber("800"))
     }
 


### PR DESCRIPTION
This changes ssml wrapping to happen with numbers of length 5 or more since 4 accidentally picks up years. Also added a special case for a 4 digit PO box number we had that was being pronounced wrong.

To test, see the SSML on https://dialogflow.cloud.google.com/cx/projects/dol-uisim-ccai-dev-app/locations/global/agents/0fd9454d-9fee-4177-809d-573ccf0dd355/flows/a6f7dd04-121c-44c9-ae2a-39ee7d40efcf/flow_creation?pageId=cdadc50f-f4f1-40e8-90d2-8cd230f3d088 and verify that "2014" is pronounced correctly when speaking through the SSML tester https://cloud.google.com/text-to-speech/#section-2