### PR TITLE
UICCAI-1025: tag filter exclusion

### DIFF
--- a/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/extension/DFCXTestBuilderExtension.kt
+++ b/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/extension/DFCXTestBuilderExtension.kt
@@ -40,10 +40,16 @@ class DFCXTestBuilderExtension () : ArgumentsProvider, BeforeAllCallback, AfterA
 
         val testCaseList = DFCXTestBuilderTestSource().getTestScenarios()
 
+        if (testCaseList.isEmpty()) {
+            println("No test cases found")
+            return
+        }
+
         val request: BatchRunTestCasesRequest = BatchRunTestCasesRequest.newBuilder()
             .setParent(Properties.AGENT_PATH)
             .addAllTestCases(testCaseList.map { testCase -> testCase.name })
             .build()
+
 
         val response = testClient.batchRunTestCasesAsync(request).get()
         val resultsList = response.resultsList.sortedBy { result -> result.name }

--- a/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/testsource/DFCXTestBuilderTestSource.kt
+++ b/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/testsource/DFCXTestBuilderTestSource.kt
@@ -32,7 +32,7 @@ class DFCXTestBuilderTestSource {
             println("Tag filters: $tagFilters")
 
             val filteredTestCaseList = testCaseList.filter { testCase ->
-                testCase.tagsList.containsAll(tagFilters)
+                tagFilters.isEmpty() || testCase.tagsList.containsAll(tagFilters)
             }.filter { testCase ->
                 !testCase.tagsList.any { tag -> tagExclusions.contains(tag) }
             }

--- a/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/testsource/DFCXTestBuilderTestSource.kt
+++ b/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/testsource/DFCXTestBuilderTestSource.kt
@@ -25,10 +25,16 @@ class DFCXTestBuilderTestSource {
         val tagFilter = Properties.DFCX_TAG_FILTER
 
         if (tagFilter != "ALL") {
-            val tagFilters = tagFilter.split(',')
+            val (tagExclusionsRaw, tagFilters) = tagFilter.split(',').partition { it.startsWith('!') }
+            val tagExclusions = tagExclusionsRaw.map { it.substring(1) }
+
+            println("Tag exclusions: $tagExclusions")
+            println("Tag filters: $tagFilters")
 
             val filteredTestCaseList = testCaseList.filter { testCase ->
                 testCase.tagsList.containsAll(tagFilters)
+            }.filter { testCase ->
+                !testCase.tagsList.any { tag -> tagExclusions.contains(tag) }
             }
 
             println("Found ${filteredTestCaseList.size} tests")


### PR DESCRIPTION
## Describe your changes
* Added support for tag filter exclusions in properties
  * Simply prefix tags with `!` to exclude them 

## Issue ticket number and link

https://dol-ewf.atlassian.net/browse/UICCAI-1025

## Agent Link and Description of How to Test Changes

https://dialogflow.cloud.google.com/cx/projects/dol-uisim-ccai-dev-app/locations/global/agents/7d8acdfb-e622-4b98-bcd0-3ba2a92fde4e

1. Create a file `cx-test/main/resources/default.properties` with the following contents:
```
credentialsUrl=file:///path/to/creds.json
agentPath=projects/dol-uisim-ccai-dev-app/locations/global/agents/7d8acdfb-e622-4b98-bcd0-3ba2a92fde4e
dfcxEndpoint=dialogflow.googleapis.com:443
dfcxTagFilter=#OC,!#E2E
```

(any of these properties can be replaced as needed)

2. Run tests
```
./gradlew cx-test:run --args src/main/resources/default.properties
```

3. Ensure that the resulting spreadsheet only has tests tagged OC and no tests tagged E2E

Dev test spreadsheet available here (access must be requested): https://docs.google.com/spreadsheets/d/1dwKyJtsTVSH3hVpWYBkAKjcBd_LAreNE4QRVrEICmno/edit#gid=0

## Checklist before requesting a review
- [x] I have performed a self-review of my changes
