### PR TITLE
UICCAI-1024: DTMF/event input support

### DIFF
--- a/cx-test-sync/src/main/kotlin/io/nuvalence/cx/tools/cxtestsync/source/artifact/DFCXSpreadsheetArtifactSource.kt
+++ b/cx-test-sync/src/main/kotlin/io/nuvalence/cx/tools/cxtestsync/source/artifact/DFCXSpreadsheetArtifactSource.kt
@@ -42,7 +42,7 @@ class DFCXSpreadsheetArtifactSource {
             }
 
             fun processTags(tags: String): List<String> {
-                return tags.split("\n").map { it.trim() }
+                return tags.split("\n").map { it.trim() }.filter { it.isNotEmpty() }
             }
 
             if (row.isEmpty() || index >= rows.size - startingRow) {

--- a/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/DFCXTestBuilderSpec.kt
+++ b/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/DFCXTestBuilderSpec.kt
@@ -34,9 +34,20 @@ class DFCXTestBuilderSpec {
 
         val fullResult = DFCXTestBuilderExtension.testClient.getTestCaseResult(testCaseResult.name)
 
+        fun getInput (turn: ConversationTurn): String {
+            return if (turn.userInput.input.dtmf.digits.isNotEmpty()) {
+                "[DTMF] ${turn.userInput.input.dtmf.digits}${if (turn.userInput.input.dtmf.finishDigit.isNotEmpty()) "|${turn.userInput.input.dtmf.finishDigit}" else ""}"
+            } else if (turn.userInput.input.event.event.isNotEmpty()) {
+                "[EVENT] ${turn.userInput.input.event.event}"
+            } else {
+                turn.userInput.input.text.text
+            }
+        }
+
         fullResult.conversationTurnsList.forEachIndexed { index, turn ->
+            val input = getInput(turn)
             val resultStep = DFCXTestBuilderResultStep(
-                userInput = turn.userInput.input.text.text,
+                userInput = input,
                 expectedAgentOutput = testCase.testCaseConversationTurnsList[index].virtualAgentOutput.textResponsesList.joinToString("\n") { responseMessage ->
                     responseMessage.textList.reduce { acc, text -> acc + text }
                 },


### PR DESCRIPTION
## Describe your changes
* Added support for DTMF and event inputs in the test spreadsheet artifact
  * Such inputs are prefixed with [DTMF] and [EVENT]
  * DTMF inputs are suffixed with `|${finishDigit}` if finish digit is present

## Issue ticket number and link

https://dol-ewf.atlassian.net/browse/UICCAI-1024

## Agent Link and Description of How to Test Changes

https://dialogflow.cloud.google.com/cx/projects/dol-uisim-ccai-dev-app/locations/global/agents/7d8acdfb-e622-4b98-bcd0-3ba2a92fde4e

1. Ensure that the agent has tests that make use of DMTF and events. The above agent has been edited to include test event implementations as the actual agent does not currently use events.

2. Create a file `cx-test/main/resources/default.properties` with the following contents:
```
credentialsUrl=file:///path/to/creds.json
agentPath=projects/dol-uisim-ccai-dev-app/locations/global/agents/7d8acdfb-e622-4b98-bcd0-3ba2a92fde4e
dfcxEndpoint=dialogflow.googleapis.com:443
```

(any of these properties can be replaced as needed)

3. Run tests
```
./gradlew cx-test:run --args src/main/resources/default.properties
```

4. Ensure that the resulting spreadsheet accurately represents DTMF and event inputs.

5. Create a file `cx-test-sync/main/resources/default.properties`  with the following contents:
```
credentialsUrl=file:///path/to/creds.json
agentPath=projects/dol-uisim-ccai-dev-app/locations/global/agents/7d8acdfb-e622-4b98-bcd0-3ba2a92fde4e
spreadsheetId=${spreadsheetIdFromPreviousRun}
dfcxEndpoint=dialogflow.googleapis.com:443
```

6. Run test sync
```
./gradlew cx-test:run --args src/main/resources/default.properties
```

7. Ensure that the resulting spreadsheet remains the same as the original, with only the results columns cleared.

* See readme for instructions on how to obtain Google Sheets API credentials
* Test spreadsheet available at: https://docs.google.com/spreadsheets/d/1RSQu_hdUnsYgs4oJmEi2AFxyfhaMT9DQtroBXu1n0iM
* Test sync spreadsheet output available at: https://docs.google.com/spreadsheets/d/1PMDwOPS_RxgYJvHXxrWYYl-K5HaVF7_9zrL7Ff5k1tI

## Checklist before requesting a review
- [x] I have performed a self-review of my changes
