### PR TITLE
UICCAI-1103: fix languageCode and other ordering bugs

### DIFF
--- a/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/AgentLanguageMerger.kt
+++ b/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/AgentLanguageMerger.kt
@@ -108,7 +108,9 @@ class AgentLanguageMerger(private val translationAgent: TranslationAgent, privat
                     val synonymArray = JsonArray()
                     synonyms.forEach { synonym -> synonymArray.add(synonym) }
                     entity.asJsonObject.remove("synonyms")
+                    entity.asJsonObject.remove("languageCode")
                     entity.asJsonObject.add("synonyms", synonymArray)
+                    entity.asJsonObject.addProperty("languageCode", languageCode)
                 }
                 prettySave(jsonObject, "$entityPath/entities/$languageCode.json")
             }

--- a/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/JsonSnippets.kt
+++ b/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/JsonSnippets.kt
@@ -2,6 +2,7 @@ package io.nuvalence.cx.tools.phrases
 
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
+import com.google.gson.JsonNull
 import com.google.gson.JsonObject
 import java.util.*
 
@@ -108,10 +109,12 @@ fun languagePhrasesToJson(singleString: Boolean, phrases: Map<String, List<Strin
 
 /**
  * Looks for assignments to the "web-site" or "web-site-fwd" session parameters, and generate
- * the corresponding -ssml variables, adding them to the parameter assignment list.
+ * the corresponding -ssml variables, adding them to the parameter assignment list. Then re-add
+ * parameters so they appear in the correct order.
  */
-fun processWebSiteParameter(jsonElement: JsonElement?) {
-    jsonElement?.asJsonArray?.let { jsonArray ->
+fun processParameters(jsonObject: JsonObject?) {
+    var parameters = jsonObject?.get("setParameterActions")
+    parameters?.asJsonArray?.let { jsonArray ->
         val toAppend = mutableMapOf<String, String?>()
         val toRemove = mutableListOf<Int>()
         jsonArray.forEachIndexed { index, element ->
@@ -130,6 +133,11 @@ fun processWebSiteParameter(jsonElement: JsonElement?) {
             newParameter.addProperty("value", value)
             jsonArray.add(newParameter)
         }
+    }
+
+    jsonObject?.remove("setParameterActions")
+    if (parameters != null && parameters !is JsonNull) {
+        jsonObject?.add("setParameterActions", parameters)
     }
 }
 

--- a/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/JsonSnippets.kt
+++ b/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/JsonSnippets.kt
@@ -91,8 +91,8 @@ fun languagePhrasesToJson(singleString: Boolean, phrases: Map<String, List<Strin
             texts.forEach { text -> innerText.add(text) }
         outerText.add("text", innerText)
         val textBlob = JsonObject()
-        textBlob.addProperty("languageCode", languageCode)
         textBlob.add("text", outerText)
+        textBlob.addProperty("languageCode", languageCode)
         messages.add(textBlob)
         if (singleString)
             messages.add(audioMessage(languageCode, texts.joinToString("\n")))


### PR DESCRIPTION
To test this: 
1. checkout main in the agent
2. checkout this branch in the import tool
3. run `export`, then `import` commands (feel free to ask me for the run configurations for these in IntelliJ if you don't have them)
4. copy the "imported" agent files to agent-p2 directory for the agent and rewrite everything, then run `npm run format`
5. Observe the git diffs and make sure the only changes are related to SSML output audio text generation; there shouldn't be languageCode or setParameterActions blocks changing places