### PR TITLE
UICCAI-1151/1152: add chips text extraction and export to spreadsheet, import/translation support

### DIFF
--- a/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/AgentLanguageMerger.kt
+++ b/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/AgentLanguageMerger.kt
@@ -108,7 +108,9 @@ class AgentLanguageMerger(private val translationAgent: TranslationAgent, privat
                     val synonymArray = JsonArray()
                     synonyms.forEach { synonym -> synonymArray.add(synonym) }
                     entity.asJsonObject.remove("synonyms")
+                    entity.asJsonObject.remove("languageCode")
                     entity.asJsonObject.add("synonyms", synonymArray)
+                    entity.asJsonObject.addProperty("languageCode", languageCode)
                 }
                 prettySave(jsonObject, "$entityPath/entities/$languageCode.json")
             }

--- a/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/AgentLanguageMerger.kt
+++ b/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/AgentLanguageMerger.kt
@@ -180,6 +180,12 @@ class AgentLanguageMerger(private val translationAgent: TranslationAgent, privat
                     processParameters(entryFulfillment)
                     processTransitionRoutes(jsonObject["transitionRoutes"]?.asJsonArray)
                 }
+                translationAgent.getPages(PhrasePath(listOf(flowName, pageName, "chips")))?.let { page ->
+                    val entryFulfillment = jsonObject["entryFulfillment"].asJsonObject
+                    replaceMessages(entryFulfillment, chipsTextToJson(page.phraseByLanguage))
+                    processParameters(entryFulfillment)
+                    processTransitionRoutes(jsonObject["transitionRoutes"]?.asJsonArray)
+                }
                 jsonObject["transitionRoutes"]?.asJsonArray?.forEach { route ->
                     route.asJsonObject["condition"]?.asString?.let { condition ->
                         translationAgent.getFlow(PhrasePath(listOf(flowName, pageName, "condition", condition)))?.let { phrases ->

--- a/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/AgentLanguageMerger.kt
+++ b/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/AgentLanguageMerger.kt
@@ -182,7 +182,14 @@ class AgentLanguageMerger(private val translationAgent: TranslationAgent, privat
                 }
                 translationAgent.getPages(PhrasePath(listOf(flowName, pageName, "chips")))?.let { page ->
                     val entryFulfillment = jsonObject["entryFulfillment"].asJsonObject
-                    replaceMessages(entryFulfillment, chipsTextToJson(page.phraseByLanguage))
+                    val messages = entryFulfillment.get("messages").asJsonArray
+                    val messagesWithChips = chipsTextToJson(page.phraseByLanguage)
+                    messagesWithChips.forEach { message ->
+                        if (message !in messages) {
+                            messages.add(message)
+                        }
+                    }
+                    replaceMessages(entryFulfillment, messages)
                     processParameters(entryFulfillment)
                     processTransitionRoutes(jsonObject["transitionRoutes"]?.asJsonArray)
                 }

--- a/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/Exporter.kt
+++ b/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/Exporter.kt
@@ -28,6 +28,7 @@ fun export(args: Array<String>) {
     val translationAgent = AgentPhrasesExtractor(agentPath).process()
     val sheetWriter = SheetWriter(url, spreadsheetId)
 
+    // add intent training phrases to Training Phrases tab
     sheetWriter.deleteTab(PhraseType.Intents.title)
     sheetWriter.addTab(PhraseType.Intents.title)
     sheetWriter.addDataToTab(
@@ -37,6 +38,7 @@ fun export(args: Array<String>) {
         listOf(200) + MutableList(translationAgent.allLanguages.size) { 500 }
     )
 
+    // add entities to Entities tab
     sheetWriter.deleteTab(PhraseType.Entities.title)
     sheetWriter.addTab(PhraseType.Entities.title)
     sheetWriter.addDataToTab(
@@ -46,6 +48,7 @@ fun export(args: Array<String>) {
         listOf(200, 200) + MutableList(translationAgent.allLanguages.size) { 500 }
     )
 
+    // add transition fulfillments to Transitions tab
     sheetWriter.deleteTab(PhraseType.Flows.title)
     sheetWriter.addTab(PhraseType.Flows.title)
     sheetWriter.addDataToTab(
@@ -55,6 +58,7 @@ fun export(args: Array<String>) {
         listOf(200, 200, 100, 300) + MutableList(translationAgent.allLanguages.size) { 500 }
     )
 
+    // add normal page fulfillments to Fulfillments tab
     sheetWriter.deleteTab(PhraseType.Pages.title)
     sheetWriter.addTab(PhraseType.Pages.title)
     sheetWriter.addDataToTab(

--- a/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/JsonSnippets.kt
+++ b/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/JsonSnippets.kt
@@ -108,6 +108,40 @@ fun languagePhrasesToJson(singleString: Boolean, phrases: Map<String, List<Strin
 }
 
 /**
+ * Similar functionality for languagePhrasesToJson, but instead of building the text messages
+ * json object, we build a custom payload with chips.
+ *
+ * @param phrases map associating a language to a list of chips values
+ */
+fun chipsTextToJson(textFields: Map<String, List<String>>): JsonArray {
+    val messages = JsonArray()
+    textFields.keys.forEach { languageCode ->
+        val texts = textFields[languageCode] ?: error("Something weird happened with key = $languageCode")
+        val payload = JsonObject()
+        val richContent = JsonArray()
+        val richContentInnerArray = JsonArray()
+        val richContentItem = JsonObject()
+        val options = JsonArray()
+        texts.forEach { chipText ->
+            val chip = JsonObject()
+            chip.addProperty("text", chipText)
+            options.add(chip)
+        }
+        richContentItem.add("options", options)
+        richContentItem.addProperty("type", "chips")
+        richContentInnerArray.add(richContentItem)
+        richContent.add(richContentInnerArray)
+        payload.add("richContent", richContent)
+        val message = JsonObject()
+        message.add("payload", payload)
+        message.addProperty("languageCode", languageCode)
+        message.addProperty("channel", "DF_MESSENGER")
+        messages.add(message)
+    }
+    return messages
+}
+
+/**
  * Looks for assignments to the "web-site" or "web-site-fwd" session parameters, and generate
  * the corresponding -ssml variables, adding them to the parameter assignment list. Then re-add
  * parameters so they appear in the correct order.

--- a/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/JsonSnippets.kt
+++ b/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/JsonSnippets.kt
@@ -2,6 +2,7 @@ package io.nuvalence.cx.tools.phrases
 
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
+import com.google.gson.JsonNull
 import com.google.gson.JsonObject
 import java.util.*
 
@@ -108,10 +109,12 @@ fun languagePhrasesToJson(singleString: Boolean, phrases: Map<String, List<Strin
 
 /**
  * Looks for assignments to the "web-site" or "web-site-fwd" session parameters, and generate
- * the corresponding -ssml variables, adding them to the parameter assignment list.
+ * the corresponding -ssml variables, adding them to the parameter assignment list. Then re-add
+ * parameters so they appear in the correct order.
  */
-fun processWebSiteParameter(jsonElement: JsonElement?) {
-    jsonElement?.asJsonArray?.let { jsonArray ->
+fun processParameters(jsonObject: JsonObject?) {
+    var parameters = jsonObject?.get("setParameterActions")
+    parameters?.asJsonArray?.let { jsonArray ->
         val toAppend = mutableMapOf<String, String?>()
         val toRemove = mutableListOf<Int>()
         jsonArray.forEachIndexed { index, element ->
@@ -130,6 +133,11 @@ fun processWebSiteParameter(jsonElement: JsonElement?) {
             newParameter.addProperty("value", value)
             jsonArray.add(newParameter)
         }
+    }
+
+    jsonObject?.remove("setParameterActions")
+    if (parameters != null && parameters !is JsonNull) {
+        jsonObject?.add("setParameterActions", parameters)
     }
 }
 

--- a/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/JsonSnippets.kt
+++ b/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/JsonSnippets.kt
@@ -91,8 +91,8 @@ fun languagePhrasesToJson(singleString: Boolean, phrases: Map<String, List<Strin
             texts.forEach { text -> innerText.add(text) }
         outerText.add("text", innerText)
         val textBlob = JsonObject()
-        textBlob.addProperty("languageCode", languageCode)
         textBlob.add("text", outerText)
+        textBlob.addProperty("languageCode", languageCode)
         messages.add(textBlob)
         if (singleString)
             messages.add(audioMessage(languageCode, texts.joinToString("\n")))


### PR DESCRIPTION
This branched off of work from https://github.com/Nuvalence/dialogflow-cx-tools/pull/42, so merge that first.

To test this: 
1. checkout main in the agent
2. checkout this branch in the import tool
3. run `export`, then `import` commands (feel free to ask me for the run configurations for these in IntelliJ if you don't have them)
4. copy the "imported" agent files to agent-p2 directory for the agent and rewrite everything, then run `npm run format`
5. Observe the git diffs and make sure chips custom payloads are not removed