### PR TITLE
Agent export

### DIFF
--- a/cx-test-sync/README.md
+++ b/cx-test-sync/README.md
@@ -101,6 +101,11 @@ The command would be:
 java -jar cx-test-sync-1.0.0-all.jar src/main/resources/default.properties
 ```
 
+## Export Agent
+
+Test execution will generate the zip file of agent before applying diffs. The zip file default will be located in project root
+as agent.zip
+
 ## Properties
 
 The following are properties that can be specified in a properties file for use by the test suite. (See: [Properties File](#properties-file)
@@ -147,3 +152,13 @@ Defaults to us-east-1 if not specified.
 - Usage: `dfcxEndpoint="<endpoint URL>"`, e.g. `dfcxEndpoint="us-east1-dialogflow.googleapis.com:443"`
 - Required: No
 - Default if not supplied: `dialogflow.googleapis.com:443`
+
+### Export Agent Path
+
+The path to export agent before applying diffs
+
+Defaults to root folder of the module
+
+- Usage: `exportAgentPath="<provide absolute path>"`, e.g. `exportAgentPath="/Users/<USERNAME>/dol/dialogflow-cx-tools/cx-test-sync/src/main/resources/export/"`
+- Required: No
+- Default if not supplied: `/Users/<USERNAME>/dol/dialogflow-cx-tools/cx-test-sync/`

--- a/cx-test-sync/src/main/kotlin/io/nuvalence/cx/tools/cxtestsync/processor/SpreadsheetProcessor.kt
+++ b/cx-test-sync/src/main/kotlin/io/nuvalence/cx/tools/cxtestsync/processor/SpreadsheetProcessor.kt
@@ -75,6 +75,8 @@ class SpreadsheetProcessor () {
         val artifactSource = DFCXSpreadsheetArtifactSource()
         val testSource = DFCXTestBuilderTestSource()
 
+        testSource.exportAgentToResource();
+
         val spreadsheetTests = artifactSource.getTestScenarios().sortedBy { it.testCaseId }
         val agentTests = testSource.getTestScenarios().sortedBy { it.testCaseId }
 

--- a/cx-test-sync/src/main/kotlin/io/nuvalence/cx/tools/cxtestsync/source/test/DFCXTestBuilderTestSource.kt
+++ b/cx-test-sync/src/main/kotlin/io/nuvalence/cx/tools/cxtestsync/source/test/DFCXTestBuilderTestSource.kt
@@ -8,6 +8,8 @@ import io.nuvalence.cx.tools.cxtestsync.model.test.DFCXInjectableTest
 import io.nuvalence.cx.tools.cxtestsync.model.test.DFCXInjectableTestStep
 import io.nuvalence.cx.tools.cxtestsync.util.Properties
 import java.io.FileOutputStream
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import java.util.*
 
 class DFCXTestBuilderTestSource {
@@ -163,7 +165,9 @@ class DFCXTestBuilderTestSource {
                         agentDetails["agentId"]).toString())
                     .setDataFormat(ExportAgentRequest.DataFormat.JSON_PACKAGE)
                     .build()
-                val filePath = Properties.EXPORT_AGENT_PATH + "agent.zip"
+                val timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss"))
+                val filePath = "${Properties.EXPORT_AGENT_PATH}agent-backup-$timestamp.zip"
+
                 val response = agentsClient.exportAgentAsync(request).get()
 
                 FileOutputStream(filePath).use { fileOutputStream ->

--- a/cx-test-sync/src/main/kotlin/io/nuvalence/cx/tools/cxtestsync/source/test/DFCXTestBuilderTestSource.kt
+++ b/cx-test-sync/src/main/kotlin/io/nuvalence/cx/tools/cxtestsync/source/test/DFCXTestBuilderTestSource.kt
@@ -151,22 +151,22 @@ class DFCXTestBuilderTestSource {
     }
 
     fun exportAgentToResource() {
-        AgentsClient.create().use { agentsClient ->
-            val agentDetails = extractInfoFromPath(Properties.AGENT_PATH)
+        AgentsClient.create(AgentsSettings.newBuilder()
+            .setEndpoint(Properties.DFCX_ENDPOINT)
+            .build())
+            .use { agentsClient ->
+                val agentDetails = extractInfoFromPath(Properties.AGENT_PATH)
+                val request = ExportAgentRequest.newBuilder()
+                    .setName(AgentName.of(
+                        agentDetails["project"],
+                        agentDetails["location"],
+                        agentDetails["agentId"]).toString())
+                    .setDataFormat(ExportAgentRequest.DataFormat.JSON_PACKAGE)
+                    .build()
+                val filePath = Properties.EXPORT_AGENT_PATH + "agent.zip"
+                val response = agentsClient.exportAgentAsync(request).get()
 
-            val request = ExportAgentRequest.newBuilder()
-                .setName(AgentName.of(
-                    agentDetails["project"],
-                    agentDetails["location"],
-                    agentDetails["agentId"]).toString())
-                .setDataFormat(ExportAgentRequest.DataFormat.JSON_PACKAGE)
-                .build()
-            val filePath = Properties.EXPORT_AGENT_PATH + "agent.zip"
-
-            val response = agentsClient.exportAgentAsync(request).get()
-            // Handle the response as needed
-
-            FileOutputStream(filePath).use { fileOutputStream ->
+                FileOutputStream(filePath).use { fileOutputStream ->
                 response.agentContent.writeTo(fileOutputStream)
             }
         }

--- a/cx-test-sync/src/main/kotlin/io/nuvalence/cx/tools/cxtestsync/util/Properties.kt
+++ b/cx-test-sync/src/main/kotlin/io/nuvalence/cx/tools/cxtestsync/util/Properties.kt
@@ -115,6 +115,6 @@ enum class PropertiesDefinition(val value: String, val type: KClass<*>, val requ
     AGENT_PATH("agentPath", String::class, true, "projects/<projectName>/locations/<location>/agents/<agentId>"),
     SPREADSHEET_ID("spreadsheetId", String::class, true, "the final segment of the spreadsheet URL, e.g. \"asdf\" if your spreadsheet URL is https://docs.google.com/spreadsheets/d/asdf"),
     DFCX_ENDPOINT("dfcxEndpoint", String::class, false, "(<region>-)dialogflow.googleapis.com:443", "dialogflow.googleapis.com:443"),
-    EXPORT_AGENT_PATH("exportAgentPath", String::class, false, "Desired package to export agent prior to applying diffs, e.g. \"/Users/ruchichhabra/dol/dialogflow-cx-tools/cx-test-sync/src/main/export/\"", Paths.get("").toAbsolutePath().toString() + "/");
+    EXPORT_AGENT_PATH("exportAgentPath", String::class, false, "Desired package to export agent prior to applying diffs, e.g. \"/Users/ruchichhabra/dol/dialogflow-cx-tools/cx-test-sync/\"", Paths.get("").toAbsolutePath().toString() + "/");
 
 }

--- a/cx-test-sync/src/main/resources/template.properties
+++ b/cx-test-sync/src/main/resources/template.properties
@@ -2,3 +2,4 @@ credentialsUrl=
 agentPath=
 spreadsheetId=
 dfcxEndpoint=
+exportAgentPath=


### PR DESCRIPTION
Added exporting of agent before applying diffs to local folder in project.
Also updated default property logic to fix the error

for running the test on your machine

you can use the same properties file and along with test, it will download the agent default in the root folder of project.