### PR TITLE
Added logic to include chatbot fulfillments in the agent export

### DIFF
--- a/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/AgentPhrasesExtractor.kt
+++ b/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/AgentPhrasesExtractor.kt
@@ -371,7 +371,12 @@ class AgentPhrasesExtractor(private val rootPath: String) {
             val outerText = element.asJsonObject["text"]
             outerText?.asJsonObject?.get("text")?.asJsonArray?.mapNotNull { it.asString }?.let { texts ->
                 if (texts.isNotEmpty()) {
-                    resultMap.getOrPut("messages") { mutableMapOf() }
+                    var key = "messages"
+                    val channelElement = element.asJsonObject["channel"]
+                    if (channelElement != null && channelElement.asString.equals("DF_MESSENGER")) {
+                        key = "chatbot-messages";
+                    }
+                    resultMap.getOrPut(key) { mutableMapOf() }
                         .getOrPut(languageCode) { mutableListOf() }
                         .addAll(texts)
                 }
@@ -381,7 +386,6 @@ class AgentPhrasesExtractor(private val rootPath: String) {
         // Convert mutable inner maps and lists to immutable ones
         return resultMap.mapValues { (_, value) -> value.mapValues { (_, list) -> list.toList() }.toMap() }
     }
-
 
     /**
      * Process event handlers and, if they have trigger fulfillment messages, extract them. Note that

--- a/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/AgentPhrasesExtractor.kt
+++ b/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/AgentPhrasesExtractor.kt
@@ -1,6 +1,7 @@
 package io.nuvalence.cx.tools.phrases
 
 import com.google.gson.JsonElement
+import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import java.io.File
 
@@ -96,18 +97,29 @@ class AgentPhrasesExtractor(private val rootPath: String) {
             processEventHandlers(jsonObject, flowName).forEach { (event, messages) ->
                 translationAgent.putFlow(PhrasePath(listOf(flowName, "", "event", event)), messages)
             }
-            // Get all transition routes and their associated condition
+            // Get all transition routes and their associated condition or intent
             jsonObject["transitionRoutes"].asJsonArray.forEach { route ->
+                val messages = processMessages(route.asJsonObject["triggerFulfillment"])
+
                 route.asJsonObject["condition"]?.asString?.let { condition ->
                     // If there are trigger fulfillment messages, capture them
-                    processMessages(route.asJsonObject["triggerFulfillment"])?.let { messages ->
-                        translationAgent.putFlow(PhrasePath(listOf(flowName, "", "condition", condition)), LanguagePhrases(messages))
+                    messages.forEach { (key, value) ->
+                        val adjustedKey = if (key.startsWith("chatbot-")) "chatbot-condition" else "condition"
+                        translationAgent.putFlow(
+                            PhrasePath(listOf(flowName, "", adjustedKey, condition)),
+                            LanguagePhrases(value)
+                        )
                     }
                 }
+
                 route.asJsonObject["intent"]?.asString?.let { intent ->
                     // If there are trigger fulfillment messages, capture them
-                    processMessages(route.asJsonObject["triggerFulfillment"])?.let { messages ->
-                        translationAgent.putFlow(PhrasePath(listOf(flowName, "", "intent", intent)), LanguagePhrases(messages))
+                    messages.forEach { (key, value) ->
+                        val adjustedKey = if (key.startsWith("chatbot-")) "chatbot-intent" else "intent"
+                        translationAgent.putFlow(
+                            PhrasePath(listOf(flowName, "", adjustedKey, intent)),
+                            LanguagePhrases(value)
+                        )
                     }
                 }
             }
@@ -119,62 +131,186 @@ class AgentPhrasesExtractor(private val rootPath: String) {
      * belong to a flow.
      */
     private fun processPages(translationAgent: TranslationAgent) {
-        // Walk all directories under the "flows" directory
         File("$rootPath/flows").listFiles()?.forEach { directory ->
             val flowPath = directory.absolutePath
             val flowName = directory.name // The directory name is the flow name
-            // Walk all files under the "pages" directory
             File("$flowPath/pages").listFiles()?.forEach { file ->
-                val pageName = file.name.removeSuffix(".json") // as in <page-name>.json minus .json
+                val pageName = file.nameWithoutExtension // as in <page-name>.json minus .json
                 val jsonObject = JsonParser.parseString(file.readText()).asJsonObject
-                // If there are entry fulfillment messages, and they are not empty, capture them.
-                jsonObject["entryFulfillment"]?.let { entryFulfillment ->
-                    val messages = processMessages(entryFulfillment)
-                    val chips = processChips(entryFulfillment)
-                    if (!messages.isNullOrEmpty()) {
+                processEntryFulfillment(jsonObject, translationAgent, flowName, pageName)
+                processTransitionRoutes(jsonObject, translationAgent, flowName, pageName)
+                processForm(jsonObject, translationAgent, flowName, pageName)
+                processPageEventHandlers(jsonObject, translationAgent, flowName, pageName)
+            }
+        }
+    }
+
+    /**
+     * Processes the entry fulfillment for a given page within a flow.
+     *
+     * Entry fulfillment messages are extracted from the provided JSON object which represents
+     * the structure of a Dialogflow CX page. These messages are then processed and added to the
+     * TranslationAgent under the specified flow and page.
+     *
+     * @param jsonObject The JSON object representing the Dialogflow CX page configuration, containing the entry fulfillment messages.
+     * @param translationAgent The TranslationAgent instance where the phrases and messages will be stored.
+     * @param flowName The name of the flow to which the page belongs. Used for organizing the phrases within the TranslationAgent.
+     * @param pageName The name of the page being processed. Used alongside the flowName to organize the phrases within the TranslationAgent.
+     */
+    private fun processEntryFulfillment(jsonObject: JsonObject, translationAgent: TranslationAgent, flowName: String, pageName: String) {
+        jsonObject["entryFulfillment"]?.let { entryFulfillment ->
+            val elements = processMessages(entryFulfillment)
+            if (!elements.isNullOrEmpty()) {
+                elements.forEach { (messageType, phraseByLanguage) ->
+                    if (phraseByLanguage.isNotEmpty()) {
                         translationAgent.putPage(
-                            PhrasePath(listOf(flowName, pageName, "message")),
-                            LanguagePhrases(messages)
+                            PhrasePath(listOf(flowName, pageName, messageType)),
+                            LanguagePhrases(phraseByLanguage)
                         )
                     }
-                    if (!chips.isNullOrEmpty()) {
-                        translationAgent.putPage(
-                            PhrasePath(listOf(flowName, pageName, "chips")),
-                            LanguagePhrases(chips))
-                    }
-                }
-                jsonObject["transitionRoutes"]?.asJsonArray?.forEach { route ->
-                    route.asJsonObject["condition"]?.asString?.let { condition ->
-                        // If there are transition route fulfillment messages, capture them
-                        processMessages(route.asJsonObject["triggerFulfillment"])?.let { messages ->
-                            translationAgent.putFlow(PhrasePath(listOf(flowName, pageName, "condition", condition)), LanguagePhrases(messages))
-                        }
-                    }
-                }
-                jsonObject["form"]?.asJsonObject?.get("parameters")?.asJsonArray?.forEach { parameterElement ->
-                    val parameter = parameterElement.asJsonObject
-                    val displayName = parameter["displayName"].asString
-                    parameter["fillBehavior"]?.asJsonObject?.let { fillBehavior ->
-                        fillBehavior["initialPromptFulfillment"]?.let { initialPrompt ->
-                            val messages = processMessages(initialPrompt)
-                            if (!messages.isNullOrEmpty())
-                                translationAgent.putPage(PhrasePath(listOf(flowName, pageName, "$displayName\ninitialPromptFulfillment")), LanguagePhrases(messages))
-                        }
-                        fillBehavior["repromptEventHandlers"]?.asJsonArray?.forEach { event ->
-                            val messages = processMessages(event.asJsonObject["triggerFulfillment"])
-                            val eventName = event.asJsonObject["event"].asString
-                            if (!messages.isNullOrEmpty())
-                                translationAgent.putPage(PhrasePath(listOf(flowName, pageName, "$displayName\nrepromptEventHandlers\n$eventName")), LanguagePhrases(messages))
-                        }
-                    }
-                }
-                // If the page has event handlers with fulfillment messages, capture them
-                processEventHandlers(jsonObject, flowName).forEach { (event, messages) ->
-                    translationAgent.putPage(PhrasePath(listOf(flowName, pageName, event)), messages)
                 }
             }
         }
     }
+
+    /**
+     * Processes the transition routes for a given page within a flow.
+     *
+     * This function iterates through the transition routes defined in a Dialogflow CX page's JSON configuration.
+     * For each route, it extracts the condition and associated trigger fulfillment messages. These messages are then
+     * processed and added to the TranslationAgent. If the messages are part of a chatbot element, their condition
+     * is adjusted to reflect this by prepending "chatbot-" to the condition string.
+     *
+     * @param jsonObject The JSON object representing the Dialogflow CX page configuration, containing transition routes.
+     * @param translationAgent The TranslationAgent instance where the phrases and messages will be stored.
+     * @param flowName The name of the flow to which the page belongs. Used for organizing the phrases within the TranslationAgent.
+     * @param pageName The name of the page being processed. Used alongside the flowName to organize the phrases within the TranslationAgent.
+     */
+    private fun processTransitionRoutes(jsonObject: JsonObject, translationAgent: TranslationAgent, flowName: String, pageName: String) {
+        jsonObject["transitionRoutes"]?.asJsonArray?.forEach { route ->
+            route.asJsonObject["condition"]?.asString?.let { condition ->
+                val messages = processMessages(route.asJsonObject["triggerFulfillment"])
+                messages.forEach { (messageType, phraseByLanguage) ->
+                    val adjustedCondition = if (messageType.startsWith("chatbot-")) "chatbot-condition" else "condition"
+                    translationAgent.putFlow(PhrasePath(listOf(flowName, pageName, adjustedCondition, condition)), LanguagePhrases(phraseByLanguage))
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Processes the form parameters of a given page within a flow.
+     *
+     * This function examines the "form" section of a Dialogflow CX page's JSON configuration.
+     * It iterates through each parameter defined under the form, capturing its display name and
+     * processing its fill behavior. The fill behavior describes how the parameter should be
+     * populated and potentially reprompted.
+     *
+     * @param jsonObject The JSON object representing the Dialogflow CX page configuration, containing form parameters.
+     * @param translationAgent The TranslationAgent instance where the phrases and messages will be stored.
+     * @param flowName The name of the flow to which the page belongs. Used for organizing the phrases within the TranslationAgent.
+     * @param pageName The name of the page being processed. Used alongside the flowName to organize the phrases within the TranslationAgent.
+     */
+    private fun processForm(jsonObject: JsonObject, translationAgent: TranslationAgent, flowName: String, pageName: String) {
+        jsonObject["form"]?.asJsonObject?.get("parameters")?.asJsonArray?.forEach { parameterElement ->
+            val parameter = parameterElement.asJsonObject
+            val displayName = parameter["displayName"].asString
+            processFillBehavior(parameter, translationAgent, flowName, pageName, displayName)
+        }
+    }
+
+    /**
+     * Processes the fill behavior for a specific parameter within a form on a Dialogflow CX page.
+     *
+     * This function focuses on the "fillBehavior" aspect of a form's parameter, which defines how the parameter
+     * should be filled and potentially reprompted for. The function delegates the detailed
+     * processing of initial prompts and reprompts to dedicated methods.
+     *
+     * @param parameter The JSON object representing a single parameter within the form, containing the fill behavior details.
+     * @param translationAgent The TranslationAgent instance where the phrases and messages will be stored.
+     * @param flowName The name of the flow to which the page belongs. Used for organizing the phrases within the TranslationAgent.
+     * @param pageName The name of the page being processed. Used alongside the flowName to organize the phrases within the TranslationAgent.
+     * @param displayName The display name of the parameter being processed. Used for reference in the phrase paths and potential logging.
+     */
+    private fun processFillBehavior(parameter: JsonObject, translationAgent: TranslationAgent, flowName: String, pageName: String, displayName: String) {
+        parameter["fillBehavior"]?.asJsonObject?.let { fillBehavior ->
+            processInitialPromptFulfillment(fillBehavior, translationAgent, flowName, pageName, displayName)
+            processRepromptEventHandlers(fillBehavior, translationAgent, flowName, pageName, displayName)
+        }
+    }
+
+    /**
+     * Processes the initial prompt fulfillment for a specific parameter within a form on a Dialogflow CX page.
+     *
+     * This function addresses the 'initialPromptFulfillment' behavior defined within the parameter's fill behavior.
+     * It extracts and processes the messages intended to initially prompt the user to provide input for the parameter.
+     * These messages are then appropriately categorized and stored in the TranslationAgent. If the messages are part
+     * of a chatbot element, their keys are adjusted to reflect this by prepending "chatbot" to the key.
+     *
+     * @param fillBehavior The JSON object representing the fill behavior of a parameter, containing details about initial prompts.
+     * @param translationAgent The TranslationAgent instance where the phrases and messages will be stored.
+     * @param flowName The name of the flow to which the page belongs. Used for organizing the phrases within the TranslationAgent.
+     * @param pageName The name of the page being processed. Used alongside the flowName to organize the phrases within the TranslationAgent.
+     * @param displayName The display name of the parameter. Used as part of the key to organize and retrieve the phrases within the TranslationAgent.
+     */
+    private fun processInitialPromptFulfillment(fillBehavior: JsonObject, translationAgent: TranslationAgent, flowName: String, pageName: String, displayName: String) {
+        fillBehavior["initialPromptFulfillment"]?.let { initialPrompt ->
+            val messages = processMessages(initialPrompt)
+            messages.forEach { (key, value) ->
+                val adjustedKey = if (key.startsWith("chatbot-")) "chatbot\n$displayName\ninitialPromptFulfillment" else "$displayName\ninitialPromptFulfillment"
+                translationAgent.putPage(PhrasePath(listOf(flowName, pageName, adjustedKey)), LanguagePhrases(value))
+            }
+        }
+    }
+
+    /**
+     * Processes the reprompt event handlers for a specific parameter within a form on a Dialogflow CX page.
+     *
+     * This function examines the 'repromptEventHandlers' defined within a parameter's fill behavior in the form.
+     * It iterates through each event handler, extracting and processing the messages that are triggered upon specific
+     * events (like 'no input' or 'no match'). These messages are intended to reprompt the user for input. The function
+     * ensures that these messages are appropriately categorized and stored in the TranslationAgent. If the messages
+     * correspond to a chatbot element, their keys are adjusted to include "chatbot" for clear identification and retrieval.
+     *
+     *
+     * @param fillBehavior The JSON object representing the fill behavior of a parameter, containing details about reprompt event handlers.
+     * @param translationAgent The TranslationAgent instance where the phrases and messages will be stored.
+     * @param flowName The name of the flow to which the page belongs. Used for organizing the phrases within the TranslationAgent.
+     * @param pageName The name of the page being processed. Used alongside the flowName to organize the phrases within the TranslationAgent.
+     * @param displayName The display name of the parameter. Used as part of the key to organize and retrieve the phrases within the TranslationAgent.
+     */
+    private fun processRepromptEventHandlers(fillBehavior: JsonObject, translationAgent: TranslationAgent, flowName: String, pageName: String, displayName: String) {
+        fillBehavior["repromptEventHandlers"]?.asJsonArray?.forEach { event ->
+            val messages = processMessages(event.asJsonObject["triggerFulfillment"])
+            val eventName = event.asJsonObject["event"].asString
+            messages.forEach { (key, value) ->
+                val adjustedKey = if (key.startsWith("chatbot-")) "chatbot\n$displayName\nrepromptEventHandlers\n$eventName" else "$displayName\nrepromptEventHandlers\n$eventName"
+                translationAgent.putPage(PhrasePath(listOf(flowName, pageName, adjustedKey)), LanguagePhrases(value))
+            }
+        }
+    }
+
+    /**
+     * Processes the event handlers associated with a specific page within a flow.
+     *
+     * This function focuses on capturing the messages and phrases triggered by event handlers on a Dialogflow CX page.
+     * Event handlers are used to define how a page responds to specific events, such as user input or session start.
+     * This function extracts those messages and stores them in the TranslationAgent, categorizing them under the specific
+     * flow and page they belong to. It utilizes the `processEventHandlers` method to extract and process the messages,
+     * then organizes them within the TranslationAgent using a structured path that includes the flow and page names.
+     *
+     * @param jsonObject The JSON object representing the Dialogflow CX page configuration, containing event handlers.
+     * @param translationAgent The TranslationAgent instance where the phrases and messages will be stored.
+     * @param flowName The name of the flow to which the page belongs. Used as part of the path for organizing the phrases within the TranslationAgent.
+     * @param pageName The name of the page being processed. Used as part of the path for organizing the phrases within the TranslationAgent.
+     */
+    private fun processPageEventHandlers(jsonObject: JsonObject, translationAgent: TranslationAgent, flowName: String, pageName: String) {
+        processEventHandlers(jsonObject, flowName).forEach { (event, messages) ->
+            translationAgent.putPage(PhrasePath(listOf(flowName, pageName, event)), messages)
+        }
+    }
+
 
     /**
      * Process the parts of a message. For intents, this also includes references to entities that
@@ -197,39 +333,55 @@ class AgentPhrasesExtractor(private val rootPath: String) {
      * and a text field; under it, you find a list of text messages. Unlike for intents,
      * fulfillment messages do not have references to parameters.
      */
-    private fun processMessages(jsonElement: JsonElement) =
-        jsonElement.asJsonObject["messages"]?.asJsonArray?.mapNotNull { element ->
-            val languageCode = element.asJsonObject["languageCode"].asString
-            val outerText = element.asJsonObject["text"]
-            val texts = outerText?.asJsonObject?.get("text")?.asJsonArray?.map { text ->
-                text.asString
-            }
-            if (texts != null) languageCode to texts else null
-        }?.toMap()
+    private fun processMessages(jsonElement: JsonElement): Map<String, Map<String, List<String>>> {
+        val resultMap = mutableMapOf<String, MutableMap<String, MutableList<String>>>()
 
-    /**
-     * Process customPayload fulfillment type with chips to translate the chip values. These have
-     * a languageCode and payload field with the text values; only the text values are
-     * captured in the sheet to be translated.
-     */
-    private fun processChips(jsonElement: JsonElement) =
-        jsonElement.asJsonObject["messages"]?.asJsonArray?.mapNotNull { element ->
-            var chipsArray = emptyList<String>()
+        jsonElement.asJsonObject["messages"]?.asJsonArray?.forEach { element ->
             val languageCode = element.asJsonObject["languageCode"].asString
-            val payload = element.asJsonObject["payload"]
-            payload?.asJsonObject?.get("richContent")?.asJsonArray?.forEach { outerList ->
+
+            // Process rich content elements like chips and HTML
+            element.asJsonObject["payload"]?.asJsonObject?.get("richContent")?.asJsonArray?.forEach { outerList ->
                 outerList.asJsonArray.forEach { customElement ->
                     val elementType = customElement.asJsonObject["type"].asString
-                    if (elementType == "chips") {
-                        val chipsValues = customElement.asJsonObject["options"].asJsonArray.map { chip ->
-                            chip.asJsonObject["text"].asString
+                    val key = "chatbot-$elementType"
+
+                    when (elementType) {
+                        "chips" -> {
+                            val chipsValues = customElement.asJsonObject["options"].asJsonArray.map { chip ->
+                                chip.asJsonObject["text"].asString
+                            }
+                            resultMap.getOrPut(key) { mutableMapOf() }
+                                .getOrPut(languageCode) { mutableListOf() }
+                                .addAll(chipsValues)
                         }
-                        chipsArray = chipsArray + chipsValues
+
+                        "html" -> {
+                            val htmlContent = customElement.asJsonObject["html"].asString
+                            if (htmlContent.isNotBlank()) {
+                                resultMap.getOrPut(key) { mutableMapOf() }
+                                    .getOrPut(languageCode) { mutableListOf() }
+                                    .add(htmlContent)
+                            }
+                        }
                     }
                 }
             }
-            if (chipsArray.isNotEmpty() && chipsArray != null) languageCode to chipsArray else null
-        }?.toMap()
+
+            // Process text elements
+            val outerText = element.asJsonObject["text"]
+            outerText?.asJsonObject?.get("text")?.asJsonArray?.mapNotNull { it.asString }?.let { texts ->
+                if (texts.isNotEmpty()) {
+                    resultMap.getOrPut("messages") { mutableMapOf() }
+                        .getOrPut(languageCode) { mutableListOf() }
+                        .addAll(texts)
+                }
+            }
+        }
+
+        // Convert mutable inner maps and lists to immutable ones
+        return resultMap.mapValues { (_, value) -> value.mapValues { (_, list) -> list.toList() }.toMap() }
+    }
+
 
     /**
      * Process event handlers and, if they have trigger fulfillment messages, extract them. Note that
@@ -237,15 +389,26 @@ class AgentPhrasesExtractor(private val rootPath: String) {
      * those for the Default Start Flow only, since we will reuse their fulfillment messages everywhere
      * when we import the agent.
      */
-    private fun processEventHandlers(jsonElement: JsonElement, flowName: String) =
-        jsonElement.asJsonObject["eventHandlers"]?.asJsonArray?.mapNotNull { handler ->
+    private fun processEventHandlers(jsonElement: JsonElement, flowName: String): Map<String, LanguagePhrases> {
+        val resultsMap = mutableMapOf<String, LanguagePhrases>()
+
+        jsonElement.asJsonObject["eventHandlers"]?.asJsonArray?.forEach { handler ->
             val event = handler.asJsonObject["event"].asString
             val messages = processMessages(handler.asJsonObject["triggerFulfillment"])
-            if (messages != null && (flowName == "Default Start Flow" ||
-                        event != "sys.no-match-default" && event != "sys.no-input-default")
-            )
-                event to LanguagePhrases(messages)
-            else null
-        }?.toMap() ?: mapOf()
 
+            messages.forEach { (key, value) ->
+                // Check if the key indicates a chatbot element and adjust the event accordingly
+                val adjustedEvent = if (key.startsWith("chatbot-")) "chatbot\n$event" else event
+
+                // Filter out the messages based on the flowName and event conditions
+                if (value.isNotEmpty() && (flowName == "Default Start Flow" ||
+                            event != "sys.no-match-default" && event != "sys.no-input-default")
+                ) {
+                    resultsMap[adjustedEvent] = LanguagePhrases(value)
+                }
+            }
+        }
+
+        return resultsMap
+    }
 }


### PR DESCRIPTION
This will export chatbot fulfillments when running the export process on the agent.

Link to example export: https://docs.google.com/spreadsheets/d/1C0BQVRsKqMuIih-2taEQM2P5Hnw-t-goEydLkfUcSyk/edit?usp=sharing