### PR TITLE
UICCAI-1409: fix ES pronunciation of 1099-G

### DIFF
--- a/cx-phrases/defaults.conf
+++ b/cx-phrases/defaults.conf
@@ -58,6 +58,11 @@
         match: "1099(-){0,1}\\s*[Gg]\\s*",
         replace: "1099-G <break time=\"300ms\"/> "
     }, {
+        # add space between 10 and 99-G so it reads naturally in Spanish
+        languages: "es",
+        match: "1099(-){0,1}\\s*[Gg]\\s*",
+        replace: "10 99-G "
+    }, {
         languages: "en",
         match: "\\s4320",
         replace: " <say-as interpret-as=\"verbatim\">4320</say-as> "


### PR DESCRIPTION
## Describe your changes

* Added space between "10" and "99(-)G" in ES output audio text for natural pronunciation

## Issue ticket number and link

https://dol-ewf.atlassian.net/browse/UICCAI-1409

## Description of How to Test Changes

1. `../gradlew run --args="export <spreadsheetId> <p1m2 agent path> <sheets API creds>"`
2. `../gradlew run --args="import <spreadsheetId> <p1m2 agent path> <target agent path> <sheets API creds>"`
3. Verify that a space has been added between "10" and "99(-)G" in the resulting agent config.

NOTE: While this has been verified by the author, there are also other changes that have occurred in the CMS tool that cause further modifications to the agent configuration, thereby adding noise. As such, the relevant changes had to be cherry-picked for the final agent PR. See: https://github.com/ny/dol-uisim-ccai-agent/pull/624