### PR TITLE
UICCAI-1420: fix 1099g-year parsing

### DIFF
--- a/cx-phrases/defaults.conf
+++ b/cx-phrases/defaults.conf
@@ -55,12 +55,12 @@
     }, {
         # add break time after 1099-G it reads naturally
         languages: "en",
-        match: "1099(-){0,1}\\s*[Gg]\\s*",
+        match: "(?<!\\$flow\\.)1099(-){0,1}\\s*[Gg]\\s*",
         replace: "1099-G <break time=\"300ms\"/> "
     }, {
         # render 1099-G as words for natural reading in Spanish
         languages: "es",
-        match: "1099(-){0,1}\\s*[Gg]\\s*",
+        match: "(?<!\\$flow\\.)1099(-){0,1}\\s*[Gg]\\s*",
         replace: "diez noventa y nueve G "
     }, {
         languages: "en",


### PR DESCRIPTION
The tool was erroneously replacing `$flow.1099g-year` with `$flow.1099-G <break time="300ms"/>`. This adds a negative lookbehind to make sure it doesn't match `$flow.1099g-year`. 

To test, you can run the export/import process and compare to main and make sure the above replacement does not happen. Alternatively, you can test the replaced regex with a regex matcher. I did both while fixing.