### PR TITLE
UICCAI-1390: test result fixes

### DIFF
--- a/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/Launcher.kt
+++ b/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/Launcher.kt
@@ -3,9 +3,11 @@ package io.nuvalence.cx.tools.cxtest
 import io.nuvalence.cx.tools.cxtest.util.Properties
 import org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
 import org.junit.platform.launcher.EngineFilter
+import org.junit.platform.launcher.LauncherDiscoveryRequest
 import org.junit.platform.launcher.TagFilter
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder
 import org.junit.platform.launcher.core.LauncherFactory
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener
 import java.io.File
 import java.net.URL
 import java.util.*
@@ -79,6 +81,9 @@ class Launcher {
             }
 
             val launcher = LauncherFactory.create()
+
+            val summaryListener = SummaryGeneratingListener()
+            launcher.registerTestExecutionListeners(summaryListener)
 
             launcher.execute(requestBuilder.build())
         }

--- a/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/Launcher.kt
+++ b/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/Launcher.kt
@@ -3,11 +3,9 @@ package io.nuvalence.cx.tools.cxtest
 import io.nuvalence.cx.tools.cxtest.util.Properties
 import org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
 import org.junit.platform.launcher.EngineFilter
-import org.junit.platform.launcher.LauncherDiscoveryRequest
 import org.junit.platform.launcher.TagFilter
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder
 import org.junit.platform.launcher.core.LauncherFactory
-import org.junit.platform.launcher.listeners.SummaryGeneratingListener
 import java.io.File
 import java.net.URL
 import java.util.*
@@ -82,14 +80,7 @@ class Launcher {
 
             val launcher = LauncherFactory.create()
 
-            val summaryListener = SummaryGeneratingListener()
-            launcher.registerTestExecutionListeners(summaryListener)
-
             launcher.execute(requestBuilder.build())
-
-            println("Tests found: ${summaryListener.summary.testsFoundCount}")
-            println("Tests succeeded: ${summaryListener.summary.testsSucceededCount}")
-            println("Tests failed: ${summaryListener.summary.testsFailedCount}")
         }
     }
 }

--- a/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/Launcher.kt
+++ b/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/Launcher.kt
@@ -86,6 +86,10 @@ class Launcher {
             launcher.registerTestExecutionListeners(summaryListener)
 
             launcher.execute(requestBuilder.build())
+
+            println("Tests found: ${summaryListener.summary.testsFoundCount}")
+            println("Tests succeeded: ${summaryListener.summary.testsSucceededCount}")
+            println("Tests failed: ${summaryListener.summary.testsFailedCount}")
         }
     }
 }

--- a/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/extension/DFCXTestBuilderExtension.kt
+++ b/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/extension/DFCXTestBuilderExtension.kt
@@ -17,7 +17,7 @@ import java.text.SimpleDateFormat
 import java.util.*
 import java.util.stream.Stream
 
-class DFCXTestBuilderExtension () : ArgumentsProvider, BeforeAllCallback, AfterAllCallback, AfterTestExecutionCallback {
+class DFCXTestBuilderExtension : ArgumentsProvider, BeforeAllCallback, AfterAllCallback, AfterTestExecutionCallback {
     companion object {
         val artifact = DFCXSpreadsheetArtifact()
         lateinit var testClient: TestCasesClient
@@ -67,10 +67,6 @@ class DFCXTestBuilderExtension () : ArgumentsProvider, BeforeAllCallback, AfterA
             val response = testClient.batchRunTestCasesAsync(request).get()
             val resultsList = response.resultsList.sortedBy { result -> result.name }
 
-            println("Raw test results:")
-            println("Tests passed: ${resultsList.count { it.testResult == TestResult.PASSED } }")
-            println("Tests failed: ${resultsList.count { it.testResult == TestResult.FAILED } }")
-
             context?.root?.getStore(ExtensionContext.Namespace.GLOBAL)
                 ?.put("testCaseEntries", testCaseList zip resultsList)
             context?.root?.getStore(ExtensionContext.Namespace.GLOBAL)
@@ -95,10 +91,6 @@ class DFCXTestBuilderExtension () : ArgumentsProvider, BeforeAllCallback, AfterA
 
         DFCXSpreadsheetArtifact.summaryInfo.testsPassed = formattedResultList.count { it.result == ResultLabel.PASS }
         DFCXSpreadsheetArtifact.summaryInfo.testsFailed = formattedResultList.count { it.result == ResultLabel.FAIL }
-
-        println("Processed test results (added to artifact summary):")
-        println("Tests passed: ${DFCXSpreadsheetArtifact.summaryInfo.testsPassed}")
-        println("Tests failed: ${DFCXSpreadsheetArtifact.summaryInfo.testsFailed}")
 
         try {
             val intentCoverage = testClient.calculateCoverage(CalculateCoverageRequest.newBuilder()


### PR DESCRIPTION
## Describe your changes

* Reworked result collection for DFCX test builder-based tests
  * Test assessment now forced to run in singular thread for collection purposes
* Added more detailed logs for result counts/summary

## Issue ticket number and link

https://dol-ewf.atlassian.net/browse/UICCAI-1390

## Testing

Run the following command:
```
./gradlew cx-test:run --args src/main/resources/default.properties 
```
where `default.properties` contains the desired properties, such as the following:
```
credentialsUrl=file:///path/to/credentials/file
agentPath=projects/<project>/locations/<location>/agents/<agentPath>
dfcxEndpoint=dialogflow.googleapis.com:443
dfcxTagFilter=!#Submission
testPackage=io.nuvalence.cx.tools.cxtest
```

Example spreadsheet output found [here](https://docs.google.com/spreadsheets/d/1TCbqDyM8F_lql6fuKTY25DryPFinqphfoQ9V-f1trQM/edit#gid=0).

Example terminal output:
<img width="1213" alt="image" src="https://github.com/Nuvalence/dialogflow-cx-tools/assets/106610715/ceecf558-b219-4e5a-92ac-62304ada5e91">


