### PR TITLE
UICCAI-1440: add support for multiple custom payload types and added attributes

### DIFF
--- a/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/AgentLanguageMerger.kt
+++ b/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/AgentLanguageMerger.kt
@@ -209,7 +209,11 @@ class AgentLanguageMerger(private val translationAgent: TranslationAgent, privat
             route.asJsonObject[transitionTrigger]?.asString?.let { entry ->
                 translationAgent.getFlow(PhrasePath(listOf(flowName, "", transitionTrigger, entry, type, channel)))?.let { flow ->
                     val entryFulfillment = route.asJsonObject["triggerFulfillment"].asJsonObject
-                    replaceMessages(entryFulfillment, languagePhrasesToJson(singleString = false, flow.messagesByLanguage))
+                    replaceMessages(entryFulfillment, languagePhrasesToJson(
+                        singleString = false,
+                        flow.messagesByLanguage,
+                        null
+                    ))
                     processParameters(entryFulfillment.asJsonObject)
                 }
             }
@@ -233,7 +237,7 @@ class AgentLanguageMerger(private val translationAgent: TranslationAgent, privat
                 val entryFulfillment = jsonObject["entryFulfillment"]?.asJsonObject
                 if (entryFulfillment != null) {
                     translationAgent.getPages(PhrasePath(listOf(flowName, pageName)))?.let { page ->
-                        val replacementMessages = languagePhrasesToJson(singleString = true, page.messagesByLanguage)
+                        val replacementMessages = languagePhrasesToJson(singleString = true, page.messagesByLanguage, entryFulfillment)
                         replaceMessages(entryFulfillment, replacementMessages)
                         val webhook = entryFulfillment.get("webhook")
                         val tags = entryFulfillment.get("tag")
@@ -263,7 +267,11 @@ class AgentLanguageMerger(private val translationAgent: TranslationAgent, privat
                         fillBehavior["initialPromptFulfillment"]?.asJsonObject?.let { initialPrompt ->
                             initialPrompt["messages"]?.asJsonArray?.forEach { message ->
                                 translationAgent.getPages(PhrasePath(listOf(flowName, pageName, "$displayName\ninitialPromptFulfillment")))?.let { phrases ->
-                                    replaceMessages(initialPrompt, languagePhrasesToJson(singleString = true, phrases.messagesByLanguage))
+                                    replaceMessages(initialPrompt, languagePhrasesToJson(
+                                        singleString = true,
+                                        phrases.messagesByLanguage,
+                                        null
+                                    ))
                                 }
                             }
                         }
@@ -273,7 +281,11 @@ class AgentLanguageMerger(private val translationAgent: TranslationAgent, privat
                                 val triggerFulfillment = event["triggerFulfillment"].asJsonObject
                                 triggerFulfillment["messages"]?.asJsonArray?.forEach { message ->
                                     translationAgent.getPages(PhrasePath(listOf(flowName, pageName, "$displayName\nrepromptEventHandlers\n$eventName")))?.let { phrases ->
-                                        replaceMessages(triggerFulfillment, languagePhrasesToJson(singleString = false, phrases.messagesByLanguage))
+                                        replaceMessages(triggerFulfillment, languagePhrasesToJson(
+                                            singleString = false,
+                                            phrases.messagesByLanguage,
+                                            null
+                                        ))
                                     }
                                 }
                             }
@@ -328,7 +340,11 @@ class AgentLanguageMerger(private val translationAgent: TranslationAgent, privat
                     else -> getPhrases(PhrasePath(pathPrefix + eventName))
                 }
                 if (phrases != null) {
-                    val replacementMessages = languagePhrasesToJson(singleString = false, phrases.messagesByLanguage)
+                    val replacementMessages = languagePhrasesToJson(
+                        singleString = false,
+                        phrases.messagesByLanguage,
+                        null
+                    )
                     replaceMessages(triggerFulfillment, replacementMessages)
                     processParameters(triggerFulfillment)
                 }

--- a/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/AgentPhrasesExtractor.kt
+++ b/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/AgentPhrasesExtractor.kt
@@ -257,6 +257,11 @@ class AgentPhrasesExtractor(private val rootPath: String) {
                         val htmlText = richContentElement.asJsonObject["html"].asString
                         messages.add(Message(listOf(htmlText), channel, elementType, event))
                     }
+                    "button" -> {
+                        val buttonText = richContentElement.asJsonObject["text"].asString
+                        val buttonEvent = richContentElement.asJsonObject["event"].asJsonObject["event"].asString
+                        messages.add(Message(listOf(buttonText), channel, elementType, buttonEvent))
+                    }
                 }
             }
         }


### PR DESCRIPTION
This adds:
- support for buttons/all extra attributes from chips/buttons
- support for importing multiple custom payload types in a single payload

Ticket:
- https://dol-ewf.atlassian.net/browse/UICCAI-1440

To test, check this branch out and run the export command on the agent. Run import and compare diffs to make sure pages with buttons/chips did not have those payloads deleted as before. You can add translations to your sheet for chips/buttons as well to see those added with the correct structure.