### PR TITLE
UICCAI-1465: added chip URL support in CMS tool

### DIFF
--- a/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/AgentPhrasesExtractor.kt
+++ b/cx-phrases/src/main/kotlin/io/nuvalence/cx/tools/phrases/AgentPhrasesExtractor.kt
@@ -250,7 +250,14 @@ class AgentPhrasesExtractor(private val rootPath: String) {
                 val elementType = richContentElement.asJsonObject["type"].asString
                 when (elementType) {
                     "chips" -> {
-                        val chipsValues = richContentElement.asJsonObject["options"].asJsonArray.map { it.asJsonObject["text"].asString }
+                        val chipsValues = richContentElement.asJsonObject["options"].asJsonArray.map {
+                            var resultString = it.asJsonObject["text"].asString
+                            val anchorUrl = it.asJsonObject["anchor"]?.asJsonObject?.get("href")?.asString
+                            if (!anchorUrl.isNullOrEmpty()) {
+                                resultString += " [$anchorUrl]"
+                            }
+                            resultString
+                        }
                         messages.add(Message(chipsValues, channel, elementType, event))
                     }
                     "html" -> {


### PR DESCRIPTION
## Describe your changes

* Updated CMS export to persist URLs in chatbot chip fulfillments
  * URLs are enclosed in bracket immediately following text
* Updated CMS import to read URLs for chatbot chip fulfillments per above spec

## Issue ticket number and link

https://dol-ewf.atlassian.net/browse/UICCAI-1465

## Testing

Run the following command:
```
../gradlew run --args="export <spreadsheetId> <agentPath> <credsPath>"
../gradlew run --args="import <spreadsheetId> <agentPath> <newAgentPath> <credsPath>"
```

Example export output found [here](https://docs.google.com/spreadsheets/d/1EItpCS9KmibJjXf8vmza1HB7Juwej-MFuTk840TedEE).

Example import diff (attribute changed based on [official documentation](https://cloud.google.com/dialogflow/cx/docs/concept/integration/dialogflow-messenger/fulfillment#suggestion_chip_response_type)):
<img width="551" alt="image" src="https://github.com/Nuvalence/dialogflow-cx-tools/assets/106610715/d28f9487-0047-4577-809b-965e1ccadafa">



