### PR TITLE
UICCAI-1510: add command to create zip and restore to DFCX agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,28 @@ cd cx-agent
 ```
 
 **Arguments**:
+* The word `generate`
 * Google Sheet ID - the string between `/d/` and `/edit#` from your Sheet URL: docs.google.com/spreadsheets/d/<mark>1vxyvOCGqh_382_ZpEWcI1rGLjzjJa4pRRXM64KjcTxU</mark>/edit#gid=1799424559
 * Your Dialogflow project ID (the numeric project id)
 * Directory where the agent and agent.zip should be created
 * URL where to find the `credentials.json` file granting access to the Google Sheet above
+
+# Running the Agent Zip/Restore Tool
+Main class: `io.nuvalence.cx.tools.cxagent.MainKt`
+
+```
+cd cx-agent
+../gradlew run --args="<arguments as described below>"
+```
+
+**Arguments**:
+* The word `zip-restore`
+* The path to a local agent directory to zip/compress
+* The path to the resulting zip file
+* (Optional) Project ID for GCP Project in which Dialogflow CX Agent is located to restore the zip file to
+* (Optional) Location in which the Dialogflow CX Agent is located (e.g. `global`)
+* (Optional) Agent ID for the Dialogflow CX Agent to restore the zip file to
+  * Note: if providing the optional parameters, you need to authenticate with GCP gcloud CLI. See `cx-agent/README.md` for more details
 
 # Running the Export / Import
 

--- a/cx-agent/README.md
+++ b/cx-agent/README.md
@@ -1,0 +1,62 @@
+# CX-AGENT
+
+This directory has a tool for either generating or restoring a Dialogflow CX agent.
+
+The generation tool can generate an agent based on a pattern defined in the root level `documentation` folder.
+
+The restore functionality can zip a folder and restore that zip file to an existing DFCX agent in GCP.
+
+## Setup
+
+### Authentication with Dialogflow CX API
+
+1. Login with the gcloud CLI to obtain credentials locally. Make sure the account you choose has access to your desired agent.
+```
+gcloud auth login
+```
+
+2. Set your project
+```
+gcloud config set project <project-name>
+```
+
+3. Set up application default credentials for use by local applications.
+```
+gcloud auth application-default login
+```
+
+
+## Running the Agent Generator
+Note that unless you are using a sheet that is already created, you will need to create your own Google Sheet.
+
+Main class: `io.nuvalence.cx.tools.cxagent.MainKt`
+
+```
+cd cx-agent
+../gradlew run --args="<arguments as described below>"
+```
+
+**Arguments**:
+* The word `generate`
+* Google Sheet ID - the string between `/d/` and `/edit#` from your Sheet URL: docs.google.com/spreadsheets/d/<mark>1vxyvOCGqh_382_ZpEWcI1rGLjzjJa4pRRXM64KjcTxU</mark>/edit#gid=1799424559
+* Your Dialogflow project ID (the numeric project id)
+* Directory where the agent and agent.zip should be created
+* URL where to find the `credentials.json` file granting access to the Google Sheet above
+
+## Running the Agent Zip/Restore Tool
+Main class: `io.nuvalence.cx.tools.cxagent.MainKt`
+
+```
+cd cx-agent
+../gradlew run --args="<arguments as described below>"
+```
+
+**Arguments**:
+* The word `zip-restore`
+* The full path to a local agent directory to zip/compress
+* The full path to the resulting zip file
+  * This should have `.zip` at the end
+* (Optional) Project ID for GCP Project in which Dialogflow CX Agent is located to restore the zip file to
+* (Optional) Location in which the Dialogflow CX Agent is located (e.g. `global`)
+* (Optional) Agent ID for the Dialogflow CX Agent to restore the zip file to
+  * This can be found in the URL for your agent like `/agents/<your-agent-id>`

--- a/cx-agent/build.gradle.kts
+++ b/cx-agent/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation("org.freemarker:freemarker:2.3.32")
     implementation("com.typesafe:config:1.4.2")
     implementation("io.github.config4k:config4k:0.5.0")
+    implementation("com.google.cloud:google-cloud-dialogflow-cx:0.48.0")
 }
 
 application {

--- a/cx-agent/src/main/kotlin/io/nuvalence/cx/tools/cxagent/Main.kt
+++ b/cx-agent/src/main/kotlin/io/nuvalence/cx/tools/cxagent/Main.kt
@@ -1,16 +1,14 @@
 package io.nuvalence.cx.tools.cxagent
 
-import java.net.URL
+import io.nuvalence.cx.tools.cxagent.generator.generateAgent
+import io.nuvalence.cx.tools.cxagent.compressor.zipRestore
 
 fun main(args: Array<String>) {
-    if (args.size < 4) {
-        error("Required parameters: <spreadsheet ID> <path where to generate the agent> <URL to credentials.json>")
+    if (args.isEmpty())
+        error("First parameter must specify the operation: generate to generate an agent, or zip-restore to zip and optionally restore an agent directory to a DFCX agent")
+    when (args.first()) {
+        "generate" -> generateAgent(args)
+        "zip-restore" -> zipRestore(args)
+        else -> error("First parameter must specify the operation: generate to generate an agent, or zip-restore to zip and optionally restore an agent directory to a DFCX agent")
     }
-    val spreadsheetId = args.first()
-    val projectId = args[1]
-    val agentPath = args[2]
-    val url = URL(args[3])
-
-    val agentModel = SheetParser(projectNumber = projectId, credentialsUrl = url, spreadsheetId = spreadsheetId).create()
-    CxAgentGenerator(agentPath, agentModel).generate()
 }

--- a/cx-agent/src/main/kotlin/io/nuvalence/cx/tools/cxagent/compressor/Compressor.kt
+++ b/cx-agent/src/main/kotlin/io/nuvalence/cx/tools/cxagent/compressor/Compressor.kt
@@ -1,0 +1,47 @@
+package io.nuvalence.cx.tools.cxagent.compressor
+
+import com.google.api.gax.rpc.ApiException
+import com.google.cloud.dialogflow.cx.v3.AgentName
+import com.google.cloud.dialogflow.cx.v3.AgentsClient
+import com.google.cloud.dialogflow.cx.v3.RestoreAgentRequest
+import com.google.protobuf.ByteString
+import io.nuvalence.cx.tools.shared.zipDirectory
+import java.nio.file.Files
+import java.nio.file.Paths
+
+fun zipRestore(args: Array<String>) {
+    if (args.size < 3) {
+        error("Required parameters: <path to local agent directory to compress> <path to resulting zip file>")
+    } else if (args.size == 3 || args.size == 6) {
+        val sourceAgentPath = args[1]
+        val targetAgentPath = args[2]
+        zipDirectory(sourceAgentPath, targetAgentPath)
+        if (args.size == 6) {
+            val projectId = args[3]
+            val location = args[4]
+            val agentId = args[5]
+            restoreAgent(targetAgentPath,  projectId, location, agentId)
+        }
+    } else {
+        error("Wrong number of parameters provided; please check the required parameters for your operation")
+    }
+
+}
+
+fun restoreAgent(zipFile: String, projectId: String, location: String, agentId: String) {
+    try {
+        val agentsClient = AgentsClient.create()
+        val agentName = AgentName.of(projectId, location, agentId)
+        val agentBytes = Files.readAllBytes(Paths.get(zipFile))
+        val agentByteString = ByteString.copyFrom(agentBytes)
+        val restoreAgentRequest = RestoreAgentRequest.newBuilder()
+            .setName(agentName.toString())
+            .setAgentContent(agentByteString)
+            .build()
+
+        agentsClient.restoreAgentAsync(restoreAgentRequest).get()
+
+    } catch (e: ApiException) {
+        print("An error happened while restoring the agent: $e")
+    }
+}

--- a/cx-agent/src/main/kotlin/io/nuvalence/cx/tools/cxagent/compressor/Compressor.kt
+++ b/cx-agent/src/main/kotlin/io/nuvalence/cx/tools/cxagent/compressor/Compressor.kt
@@ -1,6 +1,5 @@
 package io.nuvalence.cx.tools.cxagent.compressor
 
-import com.google.api.gax.rpc.ApiException
 import com.google.cloud.dialogflow.cx.v3.AgentName
 import com.google.cloud.dialogflow.cx.v3.AgentsClient
 import com.google.cloud.dialogflow.cx.v3.RestoreAgentRequest
@@ -15,7 +14,11 @@ fun zipRestore(args: Array<String>) {
     } else if (args.size == 3 || args.size == 6) {
         val sourceAgentPath = args[1]
         val targetAgentPath = args[2]
-        zipDirectory(sourceAgentPath, targetAgentPath)
+        try {
+            zipDirectory(sourceAgentPath, targetAgentPath)
+        } catch (e: Exception) {
+            print("An error occurred while attempting to create a zip file with name $targetAgentPath from the folder $sourceAgentPath: $e")
+        }
         if (args.size == 6) {
             val projectId = args[3]
             val location = args[4]
@@ -41,7 +44,7 @@ fun restoreAgent(zipFile: String, projectId: String, location: String, agentId: 
 
         agentsClient.restoreAgentAsync(restoreAgentRequest).get()
 
-    } catch (e: ApiException) {
-        print("An error happened while restoring the agent: $e")
+    } catch (e: Exception) {
+        print("An error happened while attempting to restore the zip file named $zipFile to the agent with id $agentId in project $projectId at location $location: $e")
     }
 }

--- a/cx-agent/src/main/kotlin/io/nuvalence/cx/tools/cxagent/generator/CxAgentGenerator.kt
+++ b/cx-agent/src/main/kotlin/io/nuvalence/cx/tools/cxagent/generator/CxAgentGenerator.kt
@@ -1,8 +1,8 @@
-package io.nuvalence.cx.tools.cxagent
+package io.nuvalence.cx.tools.cxagent.generator
 
 import freemarker.template.Configuration
 import freemarker.template.TemplateExceptionHandler
-import io.nuvalence.cx.tools.cxagent.model.CxAgentModel
+import io.nuvalence.cx.tools.cxagent.generator.model.CxAgentModel
 import io.nuvalence.cx.tools.shared.zipDirectory
 import java.io.File
 import java.nio.file.Paths

--- a/cx-agent/src/main/kotlin/io/nuvalence/cx/tools/cxagent/generator/Generator.kt
+++ b/cx-agent/src/main/kotlin/io/nuvalence/cx/tools/cxagent/generator/Generator.kt
@@ -1,0 +1,16 @@
+package io.nuvalence.cx.tools.cxagent.generator
+
+import java.net.URL
+
+fun generateAgent(args: Array<String>) {
+    if (args.size < 4) {
+        error("Required parameters: <spreadsheet ID> <path where to generate the agent> <URL to credentials.json>")
+    }
+    val spreadsheetId = args.first()
+    val projectId = args[1]
+    val agentPath = args[2]
+    val url = URL(args[3])
+
+    val agentModel = SheetParser(projectNumber = projectId, credentialsUrl = url, spreadsheetId = spreadsheetId).create()
+    CxAgentGenerator(agentPath, agentModel).generate()
+}

--- a/cx-agent/src/main/kotlin/io/nuvalence/cx/tools/cxagent/generator/SheetParser.kt
+++ b/cx-agent/src/main/kotlin/io/nuvalence/cx/tools/cxagent/generator/SheetParser.kt
@@ -1,7 +1,7 @@
-package io.nuvalence.cx.tools.cxagent
+package io.nuvalence.cx.tools.cxagent.generator
 
-import io.nuvalence.cx.tools.cxagent.model.*
-import io.nuvalence.cx.tools.cxagent.model.Smalltalk.Companion.smalltalkDisplayName
+import io.nuvalence.cx.tools.cxagent.generator.model.*
+import io.nuvalence.cx.tools.cxagent.generator.model.Smalltalk.Companion.smalltalkDisplayName
 import io.nuvalence.cx.tools.shared.SheetReader
 import java.net.URL
 

--- a/cx-agent/src/main/kotlin/io/nuvalence/cx/tools/cxagent/generator/model/CxAgentModel.kt
+++ b/cx-agent/src/main/kotlin/io/nuvalence/cx/tools/cxagent/generator/model/CxAgentModel.kt
@@ -1,4 +1,4 @@
-package io.nuvalence.cx.tools.cxagent.model
+package io.nuvalence.cx.tools.cxagent.generator.model
 
 import java.util.UUID
 

--- a/cx-agent/src/main/kotlin/io/nuvalence/cx/tools/cxagent/generator/model/Flow.kt
+++ b/cx-agent/src/main/kotlin/io/nuvalence/cx/tools/cxagent/generator/model/Flow.kt
@@ -1,4 +1,4 @@
-package io.nuvalence.cx.tools.cxagent.model
+package io.nuvalence.cx.tools.cxagent.generator.model
 
 import java.util.*
 

--- a/cx-agent/src/main/kotlin/io/nuvalence/cx/tools/cxagent/generator/model/Intent.kt
+++ b/cx-agent/src/main/kotlin/io/nuvalence/cx/tools/cxagent/generator/model/Intent.kt
@@ -1,4 +1,4 @@
-package io.nuvalence.cx.tools.cxagent.model
+package io.nuvalence.cx.tools.cxagent.generator.model
 
 import java.util.*
 

--- a/cx-agent/src/main/kotlin/io/nuvalence/cx/tools/cxagent/generator/model/Smalltalk.kt
+++ b/cx-agent/src/main/kotlin/io/nuvalence/cx/tools/cxagent/generator/model/Smalltalk.kt
@@ -1,6 +1,6 @@
-package io.nuvalence.cx.tools.cxagent.model
+package io.nuvalence.cx.tools.cxagent.generator.model
 
-import io.nuvalence.cx.tools.cxagent.model.SmalltalkInstance.*
+import io.nuvalence.cx.tools.cxagent.generator.model.SmalltalkInstance.*
 import java.util.*
 
 /**


### PR DESCRIPTION
This PR does a couple things:
- moves the agent generation logic to the generator directory and structures the cx-agent folder after cx-phrases and cx-test, making the argument `generate` indicate agent generation (while maintaining agent generation functionality)
- adds `zip-restore` command to zip an agent directory and optionally restore it to a DFCX agent

Details are added in the root README and in the cx-agent README