### PR TITLE
UICCAI-1512: added date ignore functionality for DFCX Test Builder assertion matching

### DIFF
--- a/cx-test/README.md
+++ b/cx-test/README.md
@@ -105,6 +105,8 @@ java -jar cx-test-1.0.0-all.jar src/main/resources/default.properties
 
 The following are properties that can be specified in a properties file for use by the test suite. (See: [Properties File](#properties-file)
 
+Note that whether a property is "required" or not determines whether it needs to be specified in the properties file. A property may be specified but not populated, in which case it is treated as an empty string.
+
 ### Credentials URL
 
 URL referencing the desired credentials file for access to the Google Sheets API. This can be a local file, indicated by the file URL protocol (`file:///`).
@@ -166,6 +168,17 @@ Determines how agent response strings are matched.
 - Usage: `matchingMode=[normal, adaptive]`
 - Required: No
 - Default if not supplied: `normal`
+
+### No-Date Match
+
+Determines whether disparate agent fulfillments should be matched with (dynamic) dates removed. New date formats and language codes may be added in code as needed.
+
+- Options:
+  - True: Matches the agent response against the expected response with dates removed from both
+  - False: Matches the full agent response against the full expected response wholesale
+- Usage: `noDateMatch=[true, false]`
+- Required: No
+- Default if not supplied: `false`
 
 ### Orchestration Mode
 

--- a/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/DFCXTestBuilderSpec.kt
+++ b/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/DFCXTestBuilderSpec.kt
@@ -6,6 +6,7 @@ import io.nuvalence.cx.tools.cxtest.extension.DFCXTestBuilderExtension
 import io.nuvalence.cx.tools.cxtest.model.test.DFCXTestBuilderResult
 import io.nuvalence.cx.tools.cxtest.model.test.DFCXTestBuilderResultStep
 import io.nuvalence.cx.tools.cxtest.model.test.ResultLabel
+import io.nuvalence.cx.tools.cxtest.util.Properties
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.extension.ExtendWith
@@ -65,7 +66,7 @@ class DFCXTestBuilderSpec {
             }
 
             if (turn.virtualAgentOutput.differencesList.any { diff -> diff.type == TestRunDifference.DiffType.UTTERANCE}) {
-                if (!isNoDateMatch(resultStep.expectedAgentOutput, resultStep.actualAgentOutput)) {
+                if (!(Properties.NO_DATE_MATCH && isNoDateMatch(resultStep.expectedAgentOutput, resultStep.actualAgentOutput, turn.userInput.input.languageCode))) {
                     resultStep.result = ResultLabel.FAIL
                 }
             }

--- a/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/DFCXTestBuilderSpec.kt
+++ b/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/DFCXTestBuilderSpec.kt
@@ -1,6 +1,7 @@
 package io.nuvalence.cx.tools.cxtest
 
 import com.google.cloud.dialogflow.cx.v3.*
+import io.nuvalence.cx.tools.cxtest.assertion.isNoDateMatch
 import io.nuvalence.cx.tools.cxtest.extension.DFCXTestBuilderExtension
 import io.nuvalence.cx.tools.cxtest.model.test.DFCXTestBuilderResult
 import io.nuvalence.cx.tools.cxtest.model.test.DFCXTestBuilderResultStep
@@ -59,10 +60,14 @@ class DFCXTestBuilderSpec {
                 diffs = turn.virtualAgentOutput.differencesList
             )
 
-            if (turn.virtualAgentOutput.differencesList.any { diff ->
-                diff.type == TestRunDifference.DiffType.PAGE || diff.type == TestRunDifference.DiffType.UTTERANCE
-            }) {
+            if (turn.virtualAgentOutput.differencesList.any { diff -> diff.type == TestRunDifference.DiffType.PAGE }) {
                 resultStep.result = ResultLabel.FAIL
+            }
+
+            if (turn.virtualAgentOutput.differencesList.any { diff -> diff.type == TestRunDifference.DiffType.UTTERANCE}) {
+                if (!isNoDateMatch(resultStep.expectedAgentOutput, resultStep.actualAgentOutput)) {
+                    resultStep.result = ResultLabel.FAIL
+                }
             }
 
             testBuilderResult.resultSteps.add(resultStep)

--- a/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/assertion/Assertions.kt
+++ b/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/assertion/Assertions.kt
@@ -60,9 +60,34 @@ fun assertFuzzyMatch(input: String, expected: String, actual: List<ResponseMessa
 }
 
 /**
+ * Asserts that the response string matches the expected string with dates removed.
+ *
+ * @param expected the expected string
+ * @param actual the actual response string
+ */
+fun isNoDateMatch(expected: String, actual: String) : Boolean {
+    val newActual = stripDates(actual)
+    val newExpected = stripDates(expected)
+
+    return newActual == newExpected
+}
+
+/**
+ * Strips dates from a string.
+ *
+ * @param input the input string
+ * @return the string with detected dates removed
+ */
+fun stripDates(input: String) : String {
+    val regex = Regex("\\b(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\\s+\\d{1,2},\\s+\\d{4}|\\b\\d{1,2}/\\d{1,2}/\\d{4}")
+    return input.replace(regex, "")
+}
+
+/**
  * Strips SSML tags from a string.
  *
  * @param input the input string
+ * @return the string with SSML tags removed
  */
 fun stripSsml(input: String): String {
     return input.replace(Regex("<.*?>"), "")

--- a/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/assertion/Assertions.kt
+++ b/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/assertion/Assertions.kt
@@ -5,6 +5,10 @@ import io.nuvalence.cx.tools.cxtest.util.Properties
 import me.xdrop.fuzzywuzzy.FuzzySearch
 import org.junit.jupiter.api.Assertions
 
+val LANGUAGE_DATE_REGEX = mapOf(
+    "en" to Regex("\\b(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\\s+\\d{1,2},\\s+\\d{4}|\\b\\d{1,2}/\\d{1,2}/\\d{4}")
+)
+
 enum class MatchingMode(val value: String) {
     NORMAL("normal") {
         override fun assertFuzzyMatchString(input: String, expected: String, actual: String, expectedRatio: Int) {
@@ -65,9 +69,9 @@ fun assertFuzzyMatch(input: String, expected: String, actual: List<ResponseMessa
  * @param expected the expected string
  * @param actual the actual response string
  */
-fun isNoDateMatch(expected: String, actual: String) : Boolean {
-    val newActual = stripDates(actual)
-    val newExpected = stripDates(expected)
+fun isNoDateMatch(expected: String, actual: String, languageCode: String) : Boolean {
+    val newActual = stripDates(actual, languageCode)
+    val newExpected = stripDates(expected, languageCode)
 
     return newActual == newExpected
 }
@@ -78,8 +82,8 @@ fun isNoDateMatch(expected: String, actual: String) : Boolean {
  * @param input the input string
  * @return the string with detected dates removed
  */
-fun stripDates(input: String) : String {
-    val regex = Regex("\\b(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\\s+\\d{1,2},\\s+\\d{4}|\\b\\d{1,2}/\\d{1,2}/\\d{4}")
+fun stripDates(input: String, languageCode: String) : String {
+    val regex = LANGUAGE_DATE_REGEX[languageCode] ?: LANGUAGE_DATE_REGEX["en"]!!
     return input.replace(regex, "")
 }
 

--- a/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/util/Properties.kt
+++ b/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/util/Properties.kt
@@ -104,7 +104,7 @@ class Properties {
                         Byte::class -> baseProperty.toByte()
                         Double::class -> baseProperty.toDouble()
                         Float::class -> baseProperty.toFloat()
-                        Boolean::class -> baseProperty.toBoolean()
+                        Boolean::class -> baseProperty.toBooleanStrict()
                         Char::class -> baseProperty[0]
                         else -> propDef.type.constructors.find { it.parameters.size == 1 && it.parameters[0].type.classifier == String::class }
                             ?.call(baseProperty)

--- a/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/util/Properties.kt
+++ b/cx-test/src/main/kotlin/io/nuvalence/cx/tools/cxtest/util/Properties.kt
@@ -6,7 +6,6 @@ import java.net.URL
 import javax.naming.ConfigurationException
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KClass
-import kotlin.reflect.KFunction
 import kotlin.reflect.KMutableProperty1
 import kotlin.reflect.KProperty
 import kotlin.reflect.full.companionObjectInstance
@@ -38,6 +37,7 @@ class Properties {
         var ORCHESTRATION_MODE: String by PropertyDelegate()
         var MATCHING_MODE: String by PropertyDelegate()
         var MATCHING_RATIO: Int by PropertyDelegate()
+        var NO_DATE_MATCH: Boolean by PropertyDelegate()
         var DFCX_TAG_FILTER: String by PropertyDelegate()
         var INCLUDE_TAGS: String by PropertyDelegate()
         var EXCLUDE_TAGS: String by PropertyDelegate()
@@ -117,17 +117,18 @@ class Properties {
 }
 
 enum class PropertiesDefinition(val value: String, val type: KClass<*>, val isRequired: (java.util.Properties) -> Boolean = { _ -> false }, val example: String, val default: String? = "") {
-    CREDENTIALS_URL("credentialsUrl", URL::class, { _ -> true }, "file:///path/to/creds/file.json"),
-    AGENT_PATH("agentPath", String::class, { _ -> true }, "projects/<projectName>/locations/<location>/agents/<agentId>"),
+    CREDENTIALS_URL("credentialsUrl", URL::class, { true }, "file:///path/to/creds/file.json"),
+    AGENT_PATH("agentPath", String::class, { true }, "projects/<projectName>/locations/<location>/agents/<agentId>"),
     SPREADSHEET_ID("spreadsheetId", String::class, isSpreadsheetIdRequired, "the final segment of the spreadsheet URL, e.g. \"asdf\" if your spreadsheet URL is https://docs.google.com/spreadsheets/d/asdf", ""),
-    DFCX_ENDPOINT("dfcxEndpoint", String::class, { _ -> false }, "(<region>-)dialogflow.googleapis.com:443", "dialogflow.googleapis.com:443"),
-    ORCHESTRATION_MODE("orchestrationMode", String::class, { _ -> false }, "[simple, comprehensive]", "simple"),
-    MATCHING_MODE("matchingMode", String::class, { _ -> false }, "[normal, adaptive]", "normal"),
-    MATCHING_RATIO("matchingRatio", Int::class, { _ -> false }, "Integer from 0-100", "80"),
-    DFCX_TAG_FILTER("dfcxTagFilter", String::class, { _ -> false }, "Comma-delimited list of DFCX test tags, e.g. \"#Tag1,#Tag2,#Tag3\", or \"ALL\"", "ALL"),
-    INCLUDE_TAGS("includeTags", String::class, { _ -> false }, "Pipe-delimited list of JUnit test spec tags, e.g. \"dfcx\", \"e2e|smoke\"", "dfcx"),
-    EXCLUDE_TAGS("excludeTags", String::class, { _ -> false }, "Pipe-delimited list of JUnit test spec tags, e.g. \"dfcx\", \"e2e|smoke\"", "e2e|smoke"),
-    TEST_PACKAGE("testPackage", String::class, { _ -> false }, "Desired package containing test specs, e.g. \"io.nuvalence.cx.tools.cxtest\"", "io.nuvalence.cx.tools.cxtest");
+    DFCX_ENDPOINT("dfcxEndpoint", String::class, { false }, "(<region>-)dialogflow.googleapis.com:443", "dialogflow.googleapis.com:443"),
+    ORCHESTRATION_MODE("orchestrationMode", String::class, { false }, "[simple, comprehensive]", "simple"),
+    MATCHING_MODE("matchingMode", String::class, { false }, "[normal, adaptive]", "normal"),
+    MATCHING_RATIO("matchingRatio", Int::class, { false }, "Integer from 0-100", "80"),
+    NO_DATE_MATCH("noDateMatch", Boolean::class, { false }, "[true, false]", "false"),
+    DFCX_TAG_FILTER("dfcxTagFilter", String::class, { false }, "Comma-delimited list of DFCX test tags, e.g. \"#Tag1,#Tag2,#Tag3\", or \"ALL\"", "ALL"),
+    INCLUDE_TAGS("includeTags", String::class, { false }, "Pipe-delimited list of JUnit test spec tags, e.g. \"dfcx\", \"e2e|smoke\"", "dfcx"),
+    EXCLUDE_TAGS("excludeTags", String::class, { false }, "Pipe-delimited list of JUnit test spec tags, e.g. \"dfcx\", \"e2e|smoke\"", "e2e|smoke"),
+    TEST_PACKAGE("testPackage", String::class, { false }, "Desired package containing test specs, e.g. \"io.nuvalence.cx.tools.cxtest\"", "io.nuvalence.cx.tools.cxtest");
 }
 
 val isSpreadsheetIdRequired : (java.util.Properties) -> Boolean = { properties ->

--- a/cx-test/src/main/resources/template.properties
+++ b/cx-test/src/main/resources/template.properties
@@ -5,6 +5,7 @@ dfcxEndpoint=dialogflow.googleapis.com:443
 orchestrationMode=
 matchingMode=
 matchingRatio=
+noDateMatch=false
 dfcxTagFilter=
 includeTags=dfcx
 excludeTags=smoke|e2e


### PR DESCRIPTION
## Describe your changes

* Added functionality to ignore dates when re-asserting on text mismatches
* Wrapped above functionality in config property `noDateMatch`

## Issue ticket number and link

* https://dol-ewf.atlassian.net/browse/UICCAI-1512

## How to Test Changes

* Before (run on main): https://docs.google.com/spreadsheets/d/1C0h78C-ARILEXQDyzLPxkQS03COUFUsRnfiWm5McXqE
* After: https://docs.google.com/spreadsheets/d/1l4sU5VKMZHARWa3S4qmhQaC_B7Yp2z3w9D_NVJZ5N_M
* After, with configs: https://docs.google.com/spreadsheets/d/14GyCjvUa-caulSmTeS0kVHycvX9sUEfPwrWHn4xVwT8
* Before (config set to false): https://docs.google.com/spreadsheets/d/1fSW_-pqr-Zv6qgMlKx9B4SaLShmXjHjR8lYzL_PD6so
* Before (config null): https://docs.google.com/spreadsheets/d/1rhiGAepiyTR9ZHvnoejVI-PJ4jo86VT1BagftmhK3_U